### PR TITLE
add registry arg to yarn add to fix yarn not using same config

### DIFF
--- a/server/nodejs.go
+++ b/server/nodejs.go
@@ -580,6 +580,7 @@ func yarnAdd(wd string, packages ...string) (err error) {
 			"--no-progress",
 			"--non-interactive",
 			"--silent",
+			"--registry=" + node.npmRegistry,
 		}
 		yarnCacheDir := os.Getenv("YARN_CACHE_DIR")
 		if yarnCacheDir != "" {


### PR DESCRIPTION
Because yarnAdd now runs in an tmp directory, it's hard to ensure it picks up the right registry with just a config file. So just pass it as an arg and be done.