### PR TITLE
return size on fs.Exists and take size on fs.ReadFile

### DIFF
--- a/server/dts_transform.go
+++ b/server/dts_transform.go
@@ -61,7 +61,7 @@ func (task *BuildTask) copyDTS(dts string, buildVersion int, resolvePrefix strin
 		resolvePrefix,
 	}, subPath...), "/"))
 	savePath := "types" + dtsPath
-	exists, _, err := fs.Exists(savePath)
+	exists, _, _, err := fs.Exists(savePath)
 	if err != nil || exists {
 		return
 	}

--- a/server/dts_transform_test.go
+++ b/server/dts_transform_test.go
@@ -140,7 +140,7 @@ func TestCopyDTS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	file, err := fs.ReadFile(fmt.Sprintf("types/v%d/test/X-ESM/index.d.ts", VERSION))
+	file, err := fs.ReadFile(fmt.Sprintf("types/v%d/test/X-ESM/index.d.ts", VERSION), 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/embed/style.css
+++ b/server/embed/style.css
@@ -344,7 +344,7 @@ i {
 .test ul li::before {
   display: inline-block;
   vertical-align: middle;
-  height: 30px;
+  min-height: 30px;
   line-height: 30px;
 }
 

--- a/server/module.go
+++ b/server/module.go
@@ -276,7 +276,7 @@ func findModule(id string) (esm *ModuleMeta, err error) {
 		}
 
 		var exists bool
-		exists, _, err = fs.Exists(path.Join("builds", id))
+		exists, _, _, err = fs.Exists(path.Join("builds", id))
 		if err == nil && !exists {
 			db.Delete(id)
 			esm = nil

--- a/server/storage/fs.go
+++ b/server/storage/fs.go
@@ -15,8 +15,8 @@ type FSDriver interface {
 }
 
 type FS interface {
-	Exists(path string) (found bool, modtime time.Time, err error)
-	ReadFile(path string) (content io.ReadSeekCloser, err error)
+	Exists(path string) (found bool, size int64, modtime time.Time, err error)
+	ReadFile(path string, size int64) (content io.ReadSeekCloser, err error)
 	WriteFile(path string, r io.Reader) (written int64, err error)
 	WriteData(path string, data []byte) error
 }

--- a/server/storage/fs_local.go
+++ b/server/storage/fs_local.go
@@ -24,7 +24,7 @@ type localFSLayer struct {
 	root string
 }
 
-func (fs *localFSLayer) Exists(name string) (bool, time.Time, error) {
+func (fs *localFSLayer) Exists(name string) (bool, int64, time.Time, error) {
 	fullPath := path.Join(fs.root, name)
 	fi, err := os.Stat(fullPath)
 	if err != nil {
@@ -32,12 +32,12 @@ func (fs *localFSLayer) Exists(name string) (bool, time.Time, error) {
 		if os.IsNotExist(err) {
 			err = nil
 		}
-		return false, modtime, err
+		return false, 0, modtime, err
 	}
-	return true, fi.ModTime(), nil
+	return true, fi.Size(), fi.ModTime(), nil
 }
 
-func (fs *localFSLayer) ReadFile(name string) (file io.ReadSeekCloser, err error) {
+func (fs *localFSLayer) ReadFile(name string, size int64) (file io.ReadSeekCloser, err error) {
 	fullPath := path.Join(fs.root, name)
 	return os.Open(fullPath)
 }


### PR DESCRIPTION
This enforces a more strict contract between fs.Exists and fs.ReadFile, which allows more versatile optimizations within fs.ReadFile for other types of drivers.