### PR TITLE
support configuring a basepath, cdn-basepath, and base-redirect

### DIFF
--- a/server/embed/index.html
+++ b/server/embed/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width" />
   <title>ESM>CDN</title>
-  <link rel="icon" type="image/svg+xml" href="/embed/assets/favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="./embed/assets/favicon.svg">
   <meta name="description"
     content="A fast, global content delivery network to transform NPM packges to standard ES Modules by esbuild." />
   <meta name="keywords" content="js,javascript,esm,npm,deno,global,fast,cdn,package,module,esbuild,transform" />
@@ -16,7 +16,8 @@
   <meta name="og:image" content="https://esm.sh/embed/assets/sceenshot-deno-types.png" />
   <meta name="twitter:image" content="https://esm.sh/embed/assets/sceenshot-deno-types.png" />
   <meta name="twitter:card" content="summary_large_image" />
-  <link rel="stylesheet" href="/embed/style.css">
+  <link rel="stylesheet" href="./embed/style.css">
+  <base href="{basePath}/" />
 </head>
 
 <body>
@@ -42,12 +43,12 @@
       location.href = 'https://' + location.host + location.pathname + location.search
     }
   </script>
-  <script type="module">
+  <script type="module" crossorigin="use-credentials">
     const query = new URLSearchParams(location.search)
     if (query.has('test')) {
-      import('/embed/test/browser/testing.js')
+      import('./embed/test/browser/testing.js')
     } else {
-      import('/embed/index.js').then(({ render }) => render('# README'))
+      import('./embed/index.js').then(({ render }) => render('# README'))
     }
   </script>
   <script nomodule>

--- a/server/embed/index.js
+++ b/server/embed/index.js
@@ -1,13 +1,14 @@
-import * as marked from '/marked'
-import hljs from '/highlight.js/lib/core'
-import javascript from '/highlight.js/lib/languages/javascript'
-import json from '/highlight.js/lib/languages/json'
-import xml from '/highlight.js/lib/languages/xml'
-import bash from '/highlight.js/lib/languages/bash'
+import * as marked from '../marked'
+import hljs from '../highlight.js/lib/core'
+import javascript from '../highlight.js/lib/languages/javascript'
+import json from '../highlight.js/lib/languages/json'
+import xml from '../highlight.js/lib/languages/xml'
+import bash from '../highlight.js/lib/languages/bash'
 
 export function render(md) {
   const mainEl = document.querySelector('main')
-  mainEl.innerHTML = marked.parse(md).replaceAll('https://esm.sh', window.origin) + `<p class="link"><a href="/?test">Testing &rarr; </a></p>`
+  const baseHref = document.querySelector('base').href
+  mainEl.innerHTML = marked.parse(md).replaceAll('{origin}', window.origin) + `<p class="link"><a href="./?test">Testing &rarr; </a></p>`
   mainEl.removeChild(mainEl.querySelector('h1'))
   mainEl.querySelectorAll('code.language-bash').forEach(block => {
     block.innerHTML = block.innerHTML.replace(/(^|\n)\$ /g, '$1')

--- a/server/server.go
+++ b/server/server.go
@@ -21,7 +21,11 @@ import (
 )
 
 var (
+	basePath       string
+	baseRedirect   bool
 	cdnDomain      string
+	typesCdnDomain string
+	cdnBasePath    string
 	cache          storage.Cache
 	db             storage.DB
 	fs             storage.FS
@@ -55,7 +59,11 @@ func Serve(efs EmbedFS) {
 	)
 	flag.IntVar(&port, "port", 80, "http server port")
 	flag.IntVar(&httpsPort, "https-port", 0, "https(autotls) server port, default is disabled")
+	flag.StringVar(&basePath, "basepath", "", "base path")
+	flag.BoolVar(&baseRedirect, "base-redirect", false, "http redrect for URLs not from basepath")
 	flag.StringVar(&cdnDomain, "cdn-domain", "", "cdn domain")
+	flag.StringVar(&typesCdnDomain, "types-cdn-domain", "", "cdn domain for only types, default is the cdn domain value")
+	flag.StringVar(&cdnBasePath, "cdn-basepath", "", "cdn base path, default is the basepath value")
 	flag.StringVar(&etcDir, "etc-dir", ".esmd", "etc dir")
 	flag.StringVar(&cacheUrl, "cache", "", "cache config, default is 'memory:default'")
 	flag.StringVar(&dbUrl, "db", "", "database config, default is 'postdb:[etc-dir]/esm.db'")
@@ -107,6 +115,13 @@ func Serve(efs EmbedFS) {
 	} else {
 		embedFS = efs
 		os.Setenv("NO_COLOR", "1") // disable log color in production
+	}
+
+	if typesCdnDomain == "" {
+		typesCdnDomain = cdnDomain
+	}
+	if cdnBasePath == "" {
+		cdnBasePath = basePath
 	}
 
 	log, err = logx.New(fmt.Sprintf("file:%s?buffer=32k", path.Join(logDir, fmt.Sprintf("main-v%d.log", VERSION))))

--- a/server/utils.go
+++ b/server/utils.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -174,4 +175,21 @@ func gogogo(d time.Duration, task func()) {
 		<-ticker.C
 		task()
 	}
+}
+
+func proto(host string) string {
+	if host == "localhost" || strings.HasPrefix(host, "localhost:") {
+		return "http"
+	}
+	return "https"
+}
+
+func origin(requestedHost string, configuredDomain string, defaultToRequestedHost bool) string {
+	if configuredDomain != "" && configuredDomain != requestedHost {
+		return fmt.Sprintf("%s://%s", proto(configuredDomain), configuredDomain)
+	}
+	if defaultToRequestedHost {
+		return fmt.Sprintf("%s://%s", proto(requestedHost), requestedHost)
+	}
+	return ""
 }

--- a/test/browser/testing.js
+++ b/test/browser/testing.js
@@ -1,4 +1,4 @@
-import queue from '/async/queue'
+import queue from '../../../async/queue'
 
 /*
   test example:
@@ -20,7 +20,7 @@ import queue from '/async/queue'
 */
 
 const q = queue(async ({ imports, testFn, $li, $status }) => {
-  const domain = localStorage.importDomain || ''
+  const domain = localStorage.importDomain || '../../..'
   const $span = document.createElement('span')
   const $t = document.createElement('em')
   const start = Date.now()
@@ -62,7 +62,7 @@ const test = async (imports, testFn) => {
   a.forEach((name, i) => {
     const $a = document.createElement('a')
     $a.innerText = name.split('?')[0]
-    $a.href = `/${name}${name.includes('?') ? '&' : '?'}dev`
+    $a.href = `./${name}${name.includes('?') ? '&' : '?'}dev`
     $imports.appendChild($a)
     if (i < a.length - 1) {
       $imports.appendChild(document.createTextNode(', '))
@@ -79,7 +79,7 @@ const test = async (imports, testFn) => {
 // init dom
 const $container = document.createElement('div')
 $container.className = 'test'
-$container.innerHTML = '<ul></ul><p class="link"><a href="/">&larr; Back </a></p>'
+$container.innerHTML = '<ul></ul><p class="link"><a href="./">&larr; Back </a></p>'
 document.querySelector('h1 > em').appendChild(document.createTextNode(' · Testing'))
 document.querySelector('main').remove()
 document.querySelector('#root').appendChild($container)
@@ -333,7 +333,7 @@ test(['preact', 'preact/hooks', 'swr?alias=react:preact/compat'], async (t) => {
 
   const fetcher = (url) => fetch(url).then((res) => res.json());
   const App = () => {
-    const { data, error } = useSWR('/status.json', fetcher)
+    const { data, error } = useSWR('./status.json', fetcher)
     useEffect(() => {
       t.$span.removeChild(t.$span.lastChild)
     }, [])


### PR DESCRIPTION
This makes the server much more versatile, and allows for it to exist within strict infrastructure.

- `--basepath` is for everything served that would NOT be from the `cdnDomain`
- `--cdn-basepath` is for everything served from the `cdnDomain` (but does not require `cdnDomain`)
- `--base-redirect` is mostly for debugging or some other unforeseen purpose, it just redirects any request that is not from either of the previously two base paths, to the non-cdn basepath.