### PR TITLE
For unexpected state after yarn add, run yarn cache clean for that pkg

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -154,6 +154,7 @@ func (task *BuildTask) Build() (esm *ModuleMeta, err error) {
 	for i := 0; i < 3; i++ {
 		err = yarnAdd(task.wd, fmt.Sprintf("%s@%s", task.Pkg.Name, task.Pkg.Version))
 		if err == nil && !fileExists(path.Join(task.wd, "node_modules", task.Pkg.Name, "package.json")) {
+			defer yarnCacheClean(task.wd, task.Pkg.Name)
 			err = fmt.Errorf("yarnAdd(%s): package.json not found", task.Pkg)
 		}
 		if err == nil {
@@ -586,6 +587,7 @@ esbuild:
 								for i := 0; i < 3; i++ {
 									err = yarnAdd(task.wd, fmt.Sprintf("%s@%s", pkg.Name, pkg.Version))
 									if err == nil && !fileExists(path.Join(task.wd, "node_modules", pkg.Name, "package.json")) {
+										defer yarnCacheClean(task.wd, pkg.Name)
 										err = fmt.Errorf("yarnAdd(%s): package.json not found", pkg)
 									}
 									if err == nil {

--- a/server/nodejs.go
+++ b/server/nodejs.go
@@ -601,6 +601,29 @@ func yarnAdd(wd string, packages ...string) (err error) {
 	return
 }
 
+func yarnCacheClean(wd string, packages ...string) {
+	if len(packages) > 0 {
+		args := []string{"cache", "clean"}
+		yarnCacheDir := os.Getenv("YARN_CACHE_DIR")
+		if yarnCacheDir != "" {
+			args = append(args, "--cache-folder", yarnCacheDir)
+		}
+		yarnMutex := os.Getenv("YARN_MUTEX")
+		if yarnMutex != "" {
+			args = append(args, "--mutex", yarnMutex)
+		}
+		cmd := exec.Command("yarn", append(args, packages...)...)
+		cmd.Dir = wd
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			log.Warnf("yarn cache clean %s: %s", strings.Join(packages, ","), err)
+		} else {
+			log.Debug("yarn cache clean %s: %s", strings.Join(packages, ","), string(output))
+		}
+	}
+	return
+}
+
 // added by @jimisaacs
 func toTypesPackageName(pkgName string) string {
 	if strings.HasPrefix(pkgName, "@") {


### PR DESCRIPTION
For some reason particular packages were permanently in a broken state on certain environments (thee package.json not found error). It took me a while to figure out what persisted data was making the error persist. The hint was that yarn add was still reporting as having succeeded, but it clearly wasn't working. 

Then finally I realized the yarn cache might have something to do with it, so I cleared it, and it fixed the broken state. So that's where these changes are coming from.