### PR TITLE
Fix Deno check precluding esm.sh to start

### DIFF
--- a/server/nodejs.go
+++ b/server/nodejs.go
@@ -633,7 +633,7 @@ func toTypesPackageName(pkgName string) string {
 }
 
 func getDenoStdVersion() (version string, err error) {
-	resp, err := httpClient.Get("https://cdn.deno.land/std/meta/versions.json")
+	resp, err := http.Get("https://cdn.deno.land/std/meta/versions.json")
 	if err != nil {
 		return
 	}

--- a/server/nodejs.go
+++ b/server/nodejs.go
@@ -633,7 +633,7 @@ func toTypesPackageName(pkgName string) string {
 }
 
 func getDenoStdVersion() (version string, err error) {
-	resp, err := http.Get("https://cdn.deno.land/std/meta/versions.json")
+	resp, err := httpClient.Get("https://cdn.deno.land/std/meta/versions.json")
 	if err != nil {
 		return
 	}

--- a/server/query.go
+++ b/server/query.go
@@ -32,6 +32,7 @@ var httpClient = &http.Client{
 		},
 		MaxIdleConnsPerHost:   6,
 		ResponseHeaderTimeout: 60 * time.Second,
+		Proxy:                 http.ProxyFromEnvironment,
 	},
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -143,7 +143,7 @@ func Serve(efs EmbedFS) {
 
 	denoStdVersion, err = getDenoStdVersion()
 	if err != nil {
-		log.Fatalf("getDenoStdVersion: %v", err)
+		log.Warnf("getDenoStdVersion: %v", err)
 	}
 	log.Debugf("https://deno.land/std@%s found", denoStdVersion)
 


### PR DESCRIPTION
This PR relates to https://github.com/esm-dev/esm.sh/issues/309
It essentially:
- Makes the Deno check optional (so that esm.sh can still run in a restricted system where the Deno site is unreachable and only an internal NPM registry exists)
- Uses `Http.Get` for it to honour env-defined http proxy URLs