### PR TITLE
feat(build): add the 'ignore-annotations' option for esbuild

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -19,16 +19,17 @@ import (
 )
 
 type BuildTask struct {
-	CdnOrigin    string            `json:"cdnOrigin"`
-	BuildVersion int               `json:"buildVersion"`
-	Pkg          Pkg               `json:"pkg"`
-	Alias        map[string]string `json:"alias"`
-	Deps         PkgSlice          `json:"deps"`
-	Target       string            `json:"target"`
-	DevMode      bool              `json:"dev"`
-	BundleMode   bool              `json:"bundle"`
-	NoRequire    bool              `json:"noRequire"`
-	KeepNames    bool              `json:"keepNames"`
+	CdnOrigin         string            `json:"cdnOrigin"`
+	BuildVersion      int               `json:"buildVersion"`
+	Pkg               Pkg               `json:"pkg"`
+	Alias             map[string]string `json:"alias"`
+	Deps              PkgSlice          `json:"deps"`
+	Target            string            `json:"target"`
+	DevMode           bool              `json:"dev"`
+	BundleMode        bool              `json:"bundle"`
+	NoRequire         bool              `json:"noRequire"`
+	KeepNames         bool              `json:"keepNames"`
+	IgnoreAnnotations bool              `json:"ignoreAnnotations"`
 
 	// state
 	id    string
@@ -53,6 +54,9 @@ func (task *BuildTask) ID() string {
 	}
 	if task.KeepNames {
 		name += ".kn"
+	}
+	if task.IgnoreAnnotations {
+		name += ".ia"
 	}
 	if task.DevMode {
 		name += ".development"
@@ -333,7 +337,8 @@ esbuild:
 		MinifyWhitespace:  !task.DevMode,
 		MinifyIdentifiers: !task.DevMode,
 		MinifySyntax:      !task.DevMode,
-		KeepNames:         task.KeepNames, // prevent class/function names erasing
+		KeepNames:         task.KeepNames,         // prevent class/function names erasing
+		IgnoreAnnotations: task.IgnoreAnnotations, // some libs maybe use wrong side-effect annotations
 		Plugins:           []api.Plugin{esmResolverPlugin},
 		Loader: map[string]api.Loader{
 			".wasm":  api.LoaderDataURL,

--- a/server/query.go
+++ b/server/query.go
@@ -410,6 +410,7 @@ func query(devMode bool) rex.Handle {
 		noCheck := ctx.Form.Has("no-check")
 		noRequire := ctx.Form.Has("no-require")
 		keepNames := ctx.Form.Has("keep-names")
+		ignoreAnnotations := ctx.Form.Has("ignore-annotations")
 
 		// force react/jsx-dev-runtime and react-refresh into `dev` mode
 		if !isDev {
@@ -454,6 +455,10 @@ func query(devMode bool) rex.Handle {
 					if endsWith(submodule, ".development") {
 						submodule = strings.TrimSuffix(submodule, ".development")
 						isDev = true
+					}
+					if endsWith(submodule, ".ia") {
+						submodule = strings.TrimSuffix(submodule, ".ia")
+						ignoreAnnotations = true
 					}
 					if endsWith(submodule, ".kn") {
 						submodule = strings.TrimSuffix(submodule, ".kn")
@@ -537,17 +542,18 @@ func query(devMode bool) rex.Handle {
 		}
 
 		task := &BuildTask{
-			CdnOrigin:    origin,
-			BuildVersion: buildVersion,
-			Pkg:          *reqPkg,
-			Alias:        alias,
-			Deps:         deps,
-			Target:       target,
-			DevMode:      isDev,
-			BundleMode:   isBundleMode || isWorker,
-			NoRequire:    noRequire,
-			KeepNames:    keepNames,
-			stage:        "init",
+			CdnOrigin:         origin,
+			BuildVersion:      buildVersion,
+			Pkg:               *reqPkg,
+			Alias:             alias,
+			Deps:              deps,
+			Target:            target,
+			DevMode:           isDev,
+			BundleMode:        isBundleMode || isWorker,
+			NoRequire:         noRequire,
+			KeepNames:         keepNames,
+			IgnoreAnnotations: ignoreAnnotations,
+			stage:             "init",
 		}
 		taskID := task.ID()
 		esm, err := findModule(taskID)


### PR DESCRIPTION
Some libs may provide wrong 'side-effect' annotations. As a result, esbuild will remove the side-effect code unexpectedly. 

For this reason esbuild provides [an option named 'IgnoreAnnotations'](https://esbuild.github.io/api/#ignore-annotations):

> It will still do automatic tree shaking of unused imports, however, since that doesn't rely on annotations from developers. Ideally this flag is only a temporary workaround.

---

[ecomfe/zrender](https://github.com/ecomfe/zrender/blob/5.3.2/package.json#L36-L39)(used by [apache/echarts](https://github.com/apache/echarts)) is a realworld example.  [Code below](https://github.com/ecomfe/zrender/blob/559d610bd0a612fa8ed5a7e6a8dd4b23a318e94d/src/all.ts#L7-L8) was removed unexpectedly:

```javascript
 registerPainter('canvas', CanvasPainter); 
 registerPainter('svg', SVGPainter); 
```

And I have opened an issue: https://github.com/ecomfe/zrender/issues/927

These packages' newer versions may fix it but the old versions could not work without this option.



