### PR TITLE
feat(build): prevent submodules bundling their local dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ esmd
 node_modules/
 target/
 pkg/
+.vscode/launch.json


### PR DESCRIPTION
When importing a submodule, esm.sh tries to bundle all its local dependencies. If a local module has its 'inner state', it may occur some errors.

---

For example, here's a pkgA

```javascript
 pkgA
   |-- lib
   |    |-- acc.js
   |    +-- print.js
   +-- index.js
```

The source code in `lib/acc.js` is something like

```javascript
// lib/acc.js
let idx = 0;
export const acc = () => ++idx;
```

The source code in `lib/print.js` is something like

```javascript
// lib/print.js
import { acc } from './acc.js';
export const print = () => console.log(acc())
```

So after building the `lib/print.js` submodule, the `lib/acc.js`'s source code will be included.

When a third party package (pkgB) importing pkgA,

```javascript
// pkgB
import { acc } 'pkgA/lib/acc.js';
import { print } 'pkgA/lib/print.js'
```

It actually uses two `pkgA/lib/acc.js` modules -- an original submodule and a copy in `pkgA/lib/print.js`. The `idx` variable is not shared.

---

the relative issue #353 