### PR TITLE
add --public-address flag

### DIFF
--- a/server/nodejs.go
+++ b/server/nodejs.go
@@ -224,7 +224,7 @@ CheckNodejs:
 	}
 	var output []byte
 	if registry == "" {
-		log.Infof("try to read npm registry config: npm config get registry", nodejsLatestLTS)
+		log.Infof("try to read npm registry config: npm config get registry")
 		output, err := exec.Command("npm", "config", "get", "registry").CombinedOutput()
 		if err == nil {
 			node.npmRegistry = strings.TrimRight(strings.TrimSpace(string(output)), "/") + "/"
@@ -232,6 +232,7 @@ CheckNodejs:
 	} else {
 		node.npmRegistry = registry
 	}
+	log.Infof("use npm registry %s", node.npmRegistry)
 
 CheckYarn:
 	output, err = exec.Command("yarn", "-v").CombinedOutput()

--- a/server/server.go
+++ b/server/server.go
@@ -39,6 +39,8 @@ var (
 	denoStdVersion string
 	// npm registry
 	registry string
+	// public address
+	publicAddress string
 )
 
 type EmbedFS interface {
@@ -74,6 +76,7 @@ func Serve(efs EmbedFS) {
 	flag.BoolVar(&noCompress, "no-compress", false, "disable compression for text content")
 	flag.BoolVar(&isDev, "dev", false, "run server in development mode")
 	flag.StringVar(&registry, "npm-registry", "", "npm registry")
+	flag.StringVar(&publicAddress, "public-address", "", "the server public address: http://esm.sh")
 
 	flag.Parse()
 

--- a/server/utils.go
+++ b/server/utils.go
@@ -263,6 +263,9 @@ func encodeAliasDepsPrefix(alias map[string]string, deps PkgSlice) string {
 }
 
 func getOrigin(host string) string {
+	if publicAddress != "" {
+		return strings.TrimSuffix(publicAddress, "/")
+	}
 	proto := "https"
 	if host == "localhost" || strings.HasPrefix(host, "localhost:") {
 		proto = "http"


### PR DESCRIPTION
the getOrigin function, always return https scheme address , but for self host , esm.sh is runing on http port.
```
	proto := "https"
	if host == "localhost" || strings.HasPrefix(host, "localhost:") {
		proto = "http"
	}
	return fmt.Sprintf("%s://%s", proto, host)
```
This allows us to set our server's real address accurately
 ```
--public-address
```
Instead of a host request header to determine the protocol and address