### PR TITLE
Don`t  auto redirect to https for self host

### DIFF
--- a/server/embed/index.html
+++ b/server/embed/index.html
@@ -39,7 +39,7 @@
     </main>
   </div>
   <script>
-    if (location.protocol === 'http:' && location.hostname !== 'localhost') {
+    if (location.protocol === 'http:' && location.hostname == 'esm.sh') {
       location.href = 'https://' + location.host + location.pathname + location.search
     }
   </script>


### PR DESCRIPTION
For self host, no ssl certificates are configured, front-end pages should not automatically jump to http addresses, and I think the jump from http to https should be done by nginx. So here for the non-official website, I removed the automatic jumping logic