### PR TITLE
Fix package nested conditions export

### DIFF
--- a/server/esm.go
+++ b/server/esm.go
@@ -95,7 +95,7 @@ func initModule(wd string, pkg Pkg, target string, isDev bool) (esm *ESM, npm Np
 								      "require": "./lib/core.js",
 								      "import": "./esm/core.js"
 								    },
-										"./lib/core.js": {
+									"./lib/core.js": {
 								      "require": "./lib/core.js",
 								      "import": "./esm/core.js"
 								    }
@@ -117,10 +117,34 @@ func initModule(wd string, pkg Pkg, target string, isDev bool) (esm *ESM, npm Np
 								hasDefines := false
 								if m, ok := defines.(map[string]interface{}); ok {
 									newDefines := map[string]interface{}{}
+
 									for key, value := range m {
 										if s, ok := value.(string); ok && s != name {
 											newDefines[key] = strings.Replace(s, "*", suffix, -1)
 											hasDefines = true
+										}
+
+										/**
+										exports: {
+											"./*": {
+												"types": "./*.d.ts",
+												"import": {
+													"types": "./esm/*.d.mts",
+													"default": "./esm/*.mjs"
+												},
+												"default": "./*.js"
+											}
+										}
+										*/
+										if s, ok := value.(map[string]interface{}); ok {
+											subNewDefinies := map[string]interface{}{}
+											for subKey, subValue := range s {
+												if s1, ok := subValue.(string); ok && s1 != name {
+													subNewDefinies[subKey] = strings.Replace(s1, "*", suffix, -1)
+													hasDefines = true
+												}
+											}
+											newDefines[key] = subNewDefinies
 										}
 									}
 									defines = newDefines
@@ -136,6 +160,7 @@ func initModule(wd string, pkg Pkg, target string, isDev bool) (esm *ESM, npm Np
 						}
 					}
 				}
+
 				if !resolved {
 					if npm.Type == "module" || npm.Module != "" {
 						// follow main module type

--- a/test/nested-conditions/nested-conditions.test.ts
+++ b/test/nested-conditions/nested-conditions.test.ts
@@ -1,0 +1,7 @@
+import { assertExists } from "https://deno.land/std@0.178.0/testing/asserts.ts";
+
+import * as utils from 'http://localhost:8080/v111/jotai@2.0.3/es2022/vanilla/utils.js'
+
+Deno.test("Nested conditions", async () => {
+  assertExists(utils.splitAtom);
+});


### PR DESCRIPTION
This PR is fix resolve the correct `nested conditions export` definition of [package.json](https://unpkg.com/browse/jotai@2.0.3/package.json)

![image](https://user-images.githubusercontent.com/7475347/224937634-6d2c5412-de1d-44fe-b558-b7198fa9f9d5.png) 

---
Visit https://esm.sh/v111/jotai@2.0.3/es2022/vanilla/utils.js

## Currently： 
Resolve to https://unpkg.com/browse/jotai@2.0.3/esm/index.mjs
![image](https://user-images.githubusercontent.com/7475347/224938175-3a5d0b17-6abf-407c-8633-f7825238e467.png)

## Expected:
Resolve to https://unpkg.com/browse/jotai@2.0.3/esm/vanilla/utils.mjs
![image](https://user-images.githubusercontent.com/7475347/224938258-951bcde5-7e2c-4104-9745-4e8786fe64a9.png)

