### PR TITLE
Add scope to config

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	BasePath         string  `json:"basePath,omitempty"`
 	NpmRegistry      string  `json:"npmRegistry,omitempty"`
 	NpmToken         string  `json:"npmToken,omitempty"`
+	NpmRegistryScope string  `json:"npmRegistryScope,omitempty"`
 	AuthSecret       string  `json:"authSecret,omitempty"`
 	NoCompress       bool    `json:"noCompress,omitempty"`
 }

--- a/server/npm.go
+++ b/server/npm.go
@@ -199,6 +199,13 @@ func fetchPackageInfo(name string, version string) (info NpmPackage, err error) 
 	}()
 
 	url := cfg.NpmRegistry + name
+	if cfg.NpmRegistryScope != "" {
+		isInScope := strings.HasPrefix(name, cfg.NpmRegistryScope)
+		if !isInScope {
+			url = "https://registry.npmjs.org/" + name
+		}
+	}
+
 	if isFullVersion {
 		url += "/" + version
 	}
@@ -374,7 +381,6 @@ func pnpmInstall(wd string, packages ...string) (err error) {
 		args,
 		"--ignore-scripts",
 		"--loglevel", "error",
-		"--registry", cfg.NpmRegistry,
 	)
 	start := time.Now()
 	cmd := exec.Command("pnpm", args...)

--- a/server/utils.go
+++ b/server/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -284,4 +285,13 @@ func restorePurgeTimers(npmDir string) {
 		toPurge(pkg, path.Join(npmDir, pkg))
 	}
 	log.Debugf("Restored %d purge timers", len(pkgs))
+}
+
+func removeHttpPrefix(s string) (string, error) {
+	for i, v := range s {
+		if v == ':' {
+			return s[i+1:], nil
+		}
+	}
+	return "", fmt.Errorf("Colon not found in string: %s", s)
 }


### PR DESCRIPTION
**Use Case:** Hosting private npm packages in a custom npm registry, [like GitHub's npm registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry), and that npm registry is not a mirror.

**Issue:** When using a custom npm registry you set the `npmRegistry` in the config and it downloads the correct npm package, but if you try and download any other package (such as a dependency) it fails because the custom npm registry does not contain any packages but private ones.

**Solution:** [Use scope in the `.npmrc`](https://docs.npmjs.com/cli/v9/configuring-npm/npmrc?v=true#auth-related-configuration), this seemed the easiest since the `.npmrc` file was being created anyway.

Not sure how to test this, any advice about that would be appreciated.