### PR TITLE
Create failing-import-with-reejs.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/failing-import-with-reejs.md
+++ b/.github/ISSUE_TEMPLATE/failing-import-with-reejs.md
@@ -1,0 +1,28 @@
+---
+name: A failing module import in Nodejs/Bun/Deno (via Reejs)
+about: Submit a report if a module fails to import in Any Supported Runtime with Reejs' URL Imports.
+title: 'Failed to import -'
+labels: reejs
+---
+
+## Failing module
+
+- **GitHub**: https://github.com/my/repo
+- **npm**: https://npmjs.com/package/my_package
+
+```js
+let package = await URLImport("https://esm.sh/my_module");
+```
+
+## Error message
+
+After running the code in `reejs repl` I got this:
+
+```
+/* your error log here */
+```
+
+## Additional info
+
+- **esm.sh version**:
+- **Paste the `reejs doctor` report:


### PR DESCRIPTION
Reejs' URL Imports is stable to the point that I believe should be able to run any modules from esm.sh!