### PR TITLE
Add support for basic auth

### DIFF
--- a/config.example.jsonc
+++ b/config.example.jsonc
@@ -50,10 +50,13 @@
   // with this scope get downloaded from the registry, default is empty.
   // Default behavior is to fetch all packages from the npm registry.
   "npmRegistryScope": "@my-scope",
-
+  // These two fields are used for basic authentication towards a private
+  // package registry, default for both is empty.
+  "npmUser": "username",
+  "npmPassword": "password",
+  
   // The npm token for private packages, default is empty.
   "npmToken": "",
-
 
   // Disable compressing the response, default is false.
   "noCompress": false,

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -27,6 +27,8 @@ type Config struct {
 	NpmRegistry      string  `json:"npmRegistry,omitempty"`
 	NpmToken         string  `json:"npmToken,omitempty"`
 	NpmRegistryScope string  `json:"npmRegistryScope,omitempty"`
+	NpmUser          string  `json:"npmUser,omitempty"`
+	NpmPassword      string  `json:"npmPassword,omitempty"`
 	AuthSecret       string  `json:"authSecret,omitempty"`
 	NoCompress       bool    `json:"noCompress,omitempty"`
 }


### PR DESCRIPTION
Basic auth is necessary in order to support certain registries, this adds support for username and password to the config json file.