### PR TITLE
Minified UMD detection

### DIFF
--- a/packages/esm-cjs-lexer/Cargo.lock
+++ b/packages/esm-cjs-lexer/Cargo.lock
@@ -14,10 +14,11 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
+ "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
@@ -40,16 +41,15 @@ checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "ast_node"
-version = "0.8.6"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf94863c5fdfee166d0907c44e5fee970123b2b7307046d35d1e671aa93afbba"
+checksum = "c09c69dffe06d222d072c878c3afe86eee2179806f20503faec97250268b4c24"
 dependencies = [
- "darling",
  "pmutil",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -66,9 +66,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "better_scoped_tls"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73e8ecdec39e98aa3b19e8cd0b8ed8f77ccb86a6b0b2dc7cd86d105438a2123"
+checksum = "794edcc9b3fb07bb4aecaa11f093fd45663b4feadb782d68303a2268bc2701de"
 dependencies = [
  "scoped-tls",
 ]
@@ -80,10 +80,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -102,57 +114,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
-
-[[package]]
-name = "enum_kind"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b940da354ae81ef0926c5eaa428207b8f4f091d3956c891dfbd124162bed99"
-dependencies = [
- "pmutil",
- "proc-macro2",
- "swc_macros_common",
- "syn",
-]
 
 [[package]]
 name = "esm-cjs-lexer"
@@ -171,30 +136,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "from_variant"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0981e470d2ab9f643df3921d54f1952ea100c39fdb6a3fdc820e20d2291df6c"
+checksum = "03ec5dc38ee19078d84a692b1c41181ff9f94331c76cee66ff0208c770b5e54f"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "swc_macros_common",
- "syn",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -215,16 +174,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -248,15 +201,15 @@ dependencies = [
 
 [[package]]
 name = "is-macro"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c068d4c6b922cd6284c609cfa6dec0e41615c9c5a1a4ba729a970d8daba05fb"
+checksum = "f4467ed1321b310c2625c5aa6c1b1ffc5de4d9e42668cf697a08fb033ee8265e"
 dependencies = [
  "Inflector",
  "pmutil",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -423,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "parking_lot"
@@ -452,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "phf_generator"
@@ -483,13 +436,13 @@ checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pmutil"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3894e5d549cccbe44afecf72922f277f603cd4bb0219c8342631ef18fffbe004"
+checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -506,18 +459,27 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.21"
+name = "psm"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -558,7 +520,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -654,7 +616,7 @@ checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -681,6 +643,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
+
+[[package]]
 name = "sourcemap"
 version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +676,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,9 +696,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
-version = "0.8.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
@@ -736,28 +722,22 @@ dependencies = [
 
 [[package]]
 name = "string_enum"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "994453cd270ad0265796eb24abf5540091ed03e681c5f3c12bc33e4db33253e1"
+checksum = "8fa4d4f81d7c05b9161f8de839975d3326328b8ba2831164b465524cc2f55252"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 2.0.25",
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "swc_atoms"
-version = "0.4.24"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79642938ff437f2217718abf30a3450b014f600847c8f4bd60fa44f88a5210ea"
+checksum = "3b1370fa1d31e18a999928aaf18f166616b16c5cb7033ced7d50d06858c5fd90"
 dependencies = [
  "once_cell",
  "rustc-hash",
@@ -769,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.29.13"
+version = "0.31.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953e1f014688eadbbd3e9131a525e8922c552540bb02b0bb6d9fdcb1375bccc4"
+checksum = "e1362dec11e2270048e686f0c7d4a9087fcf1ec9d27147c2c226929a806a86f6"
 dependencies = [
  "ahash",
  "ast_node",
@@ -797,15 +777,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.94.18"
+version = "0.107.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6fbace94cfac9a0767fb513bac02327ad074da83b7964b7c6c83cdb38beb88f"
+checksum = "e0388ff4b0a5b08277c20d88ae630ff3a0c7c8cdd0d5bc843854fa802740fcf2"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "is-macro",
  "num-bigint",
  "scoped-tls",
- "serde",
  "string_enum",
  "swc_atoms",
  "swc_common",
@@ -814,16 +793,17 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.122.25"
+version = "0.137.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e5a791ca360a54bdadd8905aa8b5c511243b06e0400593975971558ca10161"
+checksum = "330a18477af59ac728818c5c219d180c104b42515950305c72365c0aaf8e51d6"
 dependencies = [
  "either",
- "enum_kind",
  "lexical",
  "num-bigint",
  "serde",
  "smallvec",
+ "smartstring",
+ "stacker",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -833,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.80.18"
+version = "0.93.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff3dfcd70ad5ab6d06e5da0f5ca249a3264fbfd42e72b5155dff7a8fb2f24ac"
+checksum = "ffd98eaa16ea4d829f5636682dd61af01f81689a9f0ed5166b32c25b52f270b5"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -847,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.205.73"
+version = "0.231.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1353877151aa8ad2d81207a7ea94ec045dc2c38cb13fd482147fac6638fa9f"
+checksum = "908a08685068cbd35fdeb8ff4808706b465e4534fc8c962145b11db43689997b"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",
@@ -858,33 +838,33 @@ dependencies = [
 
 [[package]]
 name = "swc_eq_ignore_macros"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c20468634668c2bbab581947bb8c75c97158d5a6959f4ba33df20983b20b4f6"
+checksum = "05a95d367e228d52484c53336991fdcf47b6b553ef835d9159db4ba40efb0ee8"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "swc_macros_common"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4be988307882648d9bc7c71a6a73322b7520ef0211e920489a98f8391d8caa2"
+checksum = "7a273205ccb09b51fabe88c49f3b34c5a4631c4c00a16ae20e03111d6a42e832"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "swc_visit"
-version = "0.5.3"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f2bcb7223e185c4c7cbf5e0c1207dec6d2bfd5e72e3fb7b3e8d179747e9130"
+checksum = "e87c337fbb2d191bf371173dea6a957f01899adb8f189c6c31b122a6cfc98fc3"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -892,16 +872,16 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.5.4"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb1f3561674d84947694d41fb6d5737d19539222779baeac1b3a071a2b29428"
+checksum = "0f322730fb82f3930a450ac24de8c98523af7d34ab8cb2f46bcb405839891a99"
 dependencies = [
  "Inflector",
  "pmutil",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -909,6 +889,17 @@ name = "syn"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -950,7 +941,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -980,9 +971,9 @@ checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-id"
@@ -1013,9 +1004,9 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1057,7 +1048,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -1079,7 +1070,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1089,6 +1080,28 @@ name = "wasm-bindgen-shared"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/packages/esm-cjs-lexer/Cargo.lock
+++ b/packages/esm-cjs-lexer/Cargo.lock
@@ -125,6 +125,7 @@ version = "0.8.1"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
+ "getrandom",
  "indexmap",
  "serde",
  "serde-wasm-bindgen",
@@ -163,8 +164,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/packages/esm-cjs-lexer/Cargo.toml
+++ b/packages/esm-cjs-lexer/Cargo.toml
@@ -30,6 +30,9 @@ swc_ecma_visit = "0.93.1"
 wasm-bindgen = {version = "0.2.83", features = ["serde-serialize"]}
 serde-wasm-bindgen = "0.4.5"
 console_error_panic_hook = { version = "0.1.7", optional = true }
+# We get build error without this
+# https://docs.rs/getrandom/latest/getrandom/#webassembly-support
+getrandom = { version = "0.2", features = ["js"] }
 
 [profile.release]
 # less code to include into binary

--- a/packages/esm-cjs-lexer/Cargo.toml
+++ b/packages/esm-cjs-lexer/Cargo.toml
@@ -20,10 +20,10 @@ serde = { version = "1.0.147", features = ["derive"] }
 # swc
 # docs: https://swc.rs
 # crate: https://crates.io/search?q=swc
-swc_common = { version = "0.29.13", features = ["sourcemap"] }
-swc_ecmascript = { version = "0.205.73", features = ["parser", "visit"] }
-swc_ecma_ast = "0.94.18"
-swc_ecma_visit = "0.80.18"
+swc_common = { version = "0.31.17", features = ["sourcemap"] }
+swc_ecmascript = { version = "0.231.14", features = ["parser", "visit"] }
+swc_ecma_ast = "0.107.1"
+swc_ecma_visit = "0.93.1"
 
 # wasm-bindgen
 # docs: https://rustwasm.github.io/docs/wasm-bindgen

--- a/packages/esm-cjs-lexer/src/cjs.rs
+++ b/packages/esm-cjs-lexer/src/cjs.rs
@@ -1291,7 +1291,7 @@ fn get_expr_from_pat_or_expr(v: &PatOrExpr) -> Option<&Expr> {
 }
 
 fn get_arrow_body_as_stmts(arrow: &ArrowExpr) -> Vec<Stmt> {
-  match &arrow.body {
+  match &*arrow.body {
     BlockStmtOrExpr::BlockStmt(BlockStmt { stmts, .. }) => stmts.clone(),
     BlockStmtOrExpr::Expr(expr) => vec![Stmt::Return(ReturnStmt {
       span: DUMMY_SP,

--- a/packages/esm-cjs-lexer/src/test.rs
+++ b/packages/esm-cjs-lexer/src/test.rs
@@ -700,14 +700,74 @@ mod tests {
 
   #[test]
   fn parse_cjs_exports_case_21_3() {
+    // Webpack minified UMD output for:
+    // ```
+    // export const named = 'named-export';
+
+    // export default 'default-export';
+    // ```
+    // Manually formatted to avoid ast changes from prettier
     let source = r#"
-      !function(e,t){if("object"==typeof exports&&"object"==typeof module)module.exports=t();else if("function"==typeof define&&define.amd)define([],t);else{var r=t();for(var n in r)("object"==typeof exports?exports:e)[n]=r[n]}}(this,(function(){return function(e){var t={};function r(n){if(t[n])return t[n].exports;var o=t[n]={i:n,l:!1,exports:{}};return e[n].call(o.exports,o,o.exports,r),o.l=!0,o.exports}return r.m=e,r.c=t,r.d=function(e,t,n){r.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:n})},r.r=function(e){"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})},r.t=function(e,t){if(1&t&&(e=r(e)),8&t)return e;if(4&t&&"object"==typeof e&&e&&e.__esModule)return e;var n=Object.create(null);if(r.r(n),Object.defineProperty(n,"default",{enumerable:!0,value:e}),2&t&&"string"!=typeof e)for(var o in e)r.d(n,o,function(t){return e[t]}.bind(null,o));return n},r.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return r.d(t,"a",t),t},r.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},r.p="",r(r.s=0)}([function(e,t,r){"use strict";r.r(t),r.d(t,"named",(function(){return n}));var n="named-export";t.default="default-export"}])}));
+    !function (e, t) { 
+      if ("object" == typeof exports && "object" == typeof module) module.exports = t(); 
+      else if ("function" == typeof define && define.amd) define([], t); 
+      else { var r = t(); for (var n in r) ("object" == typeof exports ? exports : e)[n] = r[n] } 
+    }(this, (function () { 
+      return function (e) { 
+        var t = {}; 
+        function r(n) { 
+          if (t[n]) return t[n].exports; 
+          var o = t[n] = { i: n, l: !1, exports: {} }; 
+          return e[n].call(o.exports, o, o.exports, r), o.l = !0, o.exports 
+        }
+        return r.m = e, 
+          r.c = t, 
+          r.d = function (e, t, n) { 
+            r.o(e, t) || Object.defineProperty(e, t, { enumerable: !0, get: n }) 
+          }, 
+          r.r = function (e) { 
+            "undefined" != typeof Symbol && 
+            Symbol.toStringTag && 
+            Object.defineProperty(e, Symbol.toStringTag, { value: "Module" }), 
+            Object.defineProperty(e, "__esModule", { value: !0 }) 
+          }, 
+          r.t = function (e, t) { 
+            if (1 & t && (e = r(e)), 8 & t) return e; 
+            if (4 & t && "object" == typeof e && e && e.__esModule) return e; 
+            var n = Object.create(null); 
+            if (
+              r.r(n), 
+              Object.defineProperty(n, "default", { enumerable: !0, value: e }), 
+              2 & t && 
+              "string" != typeof e
+            ) for (var o in e) r.d(n, o, function (t) { return e[t] }.bind(null, o)); 
+            return n 
+          }, 
+          r.n = function (e) { 
+            var t = e && e.__esModule ? 
+              function () { return e.default } : 
+              function () { return e };
+            return r.d(t, "a", t), t 
+          }, 
+          r.o = function (e, t) { 
+            return Object.prototype.hasOwnProperty.call(e, t)
+          }, 
+          r.p = "", r(r.s = 0) 
+        }([
+          function (e, t, r) { 
+            "use strict"; 
+            r.r(t), r.d(t, "named", (function () { return n })); 
+            var n = "named-export"; 
+            t.default = "default-export";
+          }
+        ]) 
+      }));
     "#;
     let swc = SWC::parse("index.cjs", source).expect("could not parse module");
     let (exports, _) = swc
       .parse_cjs_exports("production", true)
       .expect("could not parse exports");
-    assert_eq!(exports.join(","), "default,__esModule");
+    assert_eq!(exports.join(","), "__esModule,named,default");
   }
 
   #[test]

--- a/packages/esm-cjs-lexer/src/test.rs
+++ b/packages/esm-cjs-lexer/src/test.rs
@@ -1027,7 +1027,7 @@ mod tests {
     let (exports, _) = swc
       .parse_cjs_exports("production", true)
       .expect("could not parse exports");
-    assert_eq!(exports.join(","), "__esModule,named2,named1,default");
+    assert_eq!(exports.join(","), "default,named1,named2,__esModule");
   }
 
   #[test]

--- a/packages/esm-cjs-lexer/src/test.rs
+++ b/packages/esm-cjs-lexer/src/test.rs
@@ -700,7 +700,8 @@ mod tests {
 
   #[test]
   fn parse_cjs_exports_case_21_3() {
-    // Webpack minified UMD output for:
+    // Webpack 4 minified UMD output after replacing https://github.com/glennflanagan/react-collapsible/blob/1b987617fe7c20337977a0a877574263ed7ed657/src/Collapsible.js#L1
+    // with:
     // ```
     // export const named = 'named-export';
 
@@ -768,6 +769,63 @@ mod tests {
       .parse_cjs_exports("production", true)
       .expect("could not parse exports");
     assert_eq!(exports.join(","), "__esModule,named,default");
+  }
+
+  #[test]
+  fn parse_cjs_exports_case_21_4() {
+    // Webpack 5 minified UMD output after replacing https://github.com/amrlabib/react-timer-hook/blob/46aad2022d5cfa69bb24d1f4a20a94c774ea13d7/src/index.js#L1:
+    // with:
+    // ```
+    // export const named1 = 'named-export-1';
+    // export const named2 = 'named-export-2';
+
+    // export default 'default-export';
+    // ```
+    // Manually formatted to avoid ast changes from prettier
+    let source = r#"
+    !function (e, t) {
+      "object" == typeof exports && "object" == typeof module ?
+        module.exports = t() :
+        "function" == typeof define && define.amd ?
+          define([], t) :
+          "object" == typeof exports ?
+            exports["react-timer-hook"] = t() :
+            e["react-timer-hook"] = t()
+    }(
+      "undefined" != typeof self ? self : this,
+      (() =>
+        (() => {
+          "use strict";
+          var e = {
+            d: (t, o) => {
+              for (var r in o)
+                e.o(o, r) && !e.o(t, r) && Object.defineProperty(t, r, { enumerable: !0, get: o[r] })
+            },
+            o: (e, t) => Object.prototype.hasOwnProperty.call(e, t),
+            r: e => {
+              "undefined" != typeof Symbol && Symbol.toStringTag && Object.defineProperty(e, Symbol.toStringTag, { value: "Module" }),
+                Object.defineProperty(e, "__esModule", { value: !0 })
+            }
+          },
+            t = {};
+          e.r(t),
+            e.d(t, {
+              default: () => n,
+              named1: () => o,
+              named2: () => r
+            });
+          const o = "named-export-1",
+            r = "named-export-2",
+            n = "default-export";
+          return t
+        })()
+      ));
+    "#;
+    let swc = SWC::parse("index.cjs", source).expect("could not parse module");
+    let (exports, _) = swc
+      .parse_cjs_exports("production", true)
+      .expect("could not parse exports");
+    assert_eq!(exports.join(","), "__esModule,named-export-1,named-export-2,default");
   }
 
   #[test]

--- a/packages/esm-cjs-lexer/src/test.rs
+++ b/packages/esm-cjs-lexer/src/test.rs
@@ -830,6 +830,80 @@ mod tests {
 
   #[test]
   fn parse_cjs_exports_case_21_5() {
+    // Webpack 5 minified UMD output after replacing https://github.com/amrlabib/react-timer-hook/blob/46aad2022d5cfa69bb24d1f4a20a94c774ea13d7/src/index.js#L1:
+    // with:
+    // ```
+    // import { useEffect } from "react";
+
+    // export default function useFn() {
+    //   useEffect(() => {}, []);
+    // }
+
+    // export const named1 = "named-export-1";
+    // export const named2 = "named-export-2";
+    // ```
+    // Formatted with Deno to avoid ast changes from prettier
+    let source = r#"
+    !function (e, t) {
+      "object" == typeof exports && "object" == typeof module
+        ? module.exports = t(require("react"))
+        : "function" == typeof define && define.amd
+        ? define(["react"], t)
+        : "object" == typeof exports
+        ? exports["react-timer-hook"] = t(require("react"))
+        : e["react-timer-hook"] = t(e.react);
+    }("undefined" != typeof self ? self : this, (e) =>
+      (() => {
+        "use strict";
+        var t = {
+            156: (t) => {
+              t.exports = e;
+            },
+          },
+          r = {};
+        function o(e) {
+          var n = r[e];
+          if (void 0 !== n) return n.exports;
+          var a = r[e] = { exports: {} };
+          return t[e](a, a.exports, o), a.exports;
+        }
+        o.n = (e) => {
+          var t = e && e.__esModule ? () => e.default : () => e;
+          return o.d(t, { a: t }), t;
+        },
+          o.d = (e, t) => {
+            for (var r in t) {
+              o.o(t, r) && !o.o(e, r) &&
+                Object.defineProperty(e, r, { enumerable: !0, get: t[r] });
+            }
+          },
+          o.o = (e, t) => Object.prototype.hasOwnProperty.call(e, t),
+          o.r = (e) => {
+            "undefined" != typeof Symbol && Symbol.toStringTag &&
+            Object.defineProperty(e, Symbol.toStringTag, { value: "Module" }),
+              Object.defineProperty(e, "__esModule", { value: !0 });
+          };
+        var n = {};
+        return (() => {
+          o.r(n), o.d(n, { default: () => t, named1: () => r, named2: () => a });
+          var e = o(156);
+          function t() {
+            (0, e.useEffect)(() => {}, []);
+          }
+          const r = "named-export-1", a = "named-export-2";
+        })(),
+          n;
+      })());    
+    "#;
+    let swc = SWC::parse("index.cjs", source).expect("could not parse module");
+    let (exports, _) = swc
+      .parse_cjs_exports("production", true)
+      .expect("could not parse exports");
+    assert_eq!(exports.join(","), "__esModule,default,named1,named2");
+  }
+
+  #[test]
+  fn parse_cjs_exports_case_21_6() {
     // Webpack 5 minified UMD output after replacing https://github.com/xmtp/xmtp-js-content-types/blob/c3cac4842c98785a0436240148f228c654c919c8/remote-attachment/src/index.ts
     // with:
     // ```
@@ -871,7 +945,7 @@ mod tests {
   }
 
   #[test]
-  fn parse_cjs_exports_case_21_6() {
+  fn parse_cjs_exports_case_21_7() {
     // Webpack 5 minified UMD output after replacing https://github.com/xmtp/xmtp-js-content-types/blob/c3cac4842c98785a0436240148f228c654c919c8/remote-attachment/src/index.ts
     // with:
     // ```

--- a/packages/esm-cjs-lexer/src/test.rs
+++ b/packages/esm-cjs-lexer/src/test.rs
@@ -699,6 +699,18 @@ mod tests {
   }
 
   #[test]
+  fn parse_cjs_exports_case_21_3() {
+    let source = r#"
+      !function(e,t){if("object"==typeof exports&&"object"==typeof module)module.exports=t();else if("function"==typeof define&&define.amd)define([],t);else{var r=t();for(var n in r)("object"==typeof exports?exports:e)[n]=r[n]}}(this,(function(){return function(e){var t={};function r(n){if(t[n])return t[n].exports;var o=t[n]={i:n,l:!1,exports:{}};return e[n].call(o.exports,o,o.exports,r),o.l=!0,o.exports}return r.m=e,r.c=t,r.d=function(e,t,n){r.o(e,t)||Object.defineProperty(e,t,{enumerable:!0,get:n})},r.r=function(e){"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})},r.t=function(e,t){if(1&t&&(e=r(e)),8&t)return e;if(4&t&&"object"==typeof e&&e&&e.__esModule)return e;var n=Object.create(null);if(r.r(n),Object.defineProperty(n,"default",{enumerable:!0,value:e}),2&t&&"string"!=typeof e)for(var o in e)r.d(n,o,function(t){return e[t]}.bind(null,o));return n},r.n=function(e){var t=e&&e.__esModule?function(){return e.default}:function(){return e};return r.d(t,"a",t),t},r.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},r.p="",r(r.s=0)}([function(e,t,r){"use strict";r.r(t),r.d(t,"named",(function(){return n}));var n="named-export";t.default="default-export"}])}));
+    "#;
+    let swc = SWC::parse("index.cjs", source).expect("could not parse module");
+    let (exports, _) = swc
+      .parse_cjs_exports("production", true)
+      .expect("could not parse exports");
+    assert_eq!(exports.join(","), "default,__esModule");
+  }
+
+  #[test]
   fn parse_cjs_exports_case_22() {
     let source = r#"
       var url = module.exports = {};
@@ -737,7 +749,6 @@ mod tests {
     assert_eq!(exports.join(","), "__esModule,foo");
     assert_eq!(reexports.join(","), "./lib");
   }
-
 
   #[test]
   fn parse_cjs_exports_case_24() {

--- a/packages/esm-cjs-lexer/src/test.rs
+++ b/packages/esm-cjs-lexer/src/test.rs
@@ -825,7 +825,7 @@ mod tests {
     let (exports, _) = swc
       .parse_cjs_exports("production", true)
       .expect("could not parse exports");
-    assert_eq!(exports.join(","), "__esModule,named-export-1,named-export-2,default");
+    assert_eq!(exports.join(","), "__esModule,default,named1,named2");
   }
 
   #[test]

--- a/packages/esm-cjs-lexer/src/test.rs
+++ b/packages/esm-cjs-lexer/src/test.rs
@@ -871,6 +871,49 @@ mod tests {
   }
 
   #[test]
+  fn parse_cjs_exports_case_21_6() {
+    // Webpack 5 minified UMD output after replacing https://github.com/xmtp/xmtp-js-content-types/blob/c3cac4842c98785a0436240148f228c654c919c8/remote-attachment/src/index.ts
+    // with:
+    // ```
+    // export const named1 = 'named-export-1';
+    // export const named2 = 'named-export-2';
+
+    // export default 'default-export';
+    // ```
+    // Formatted with Deno to avoid ast changes from prettier
+    let source = r#"
+    !function (e, t) {
+      "object" == typeof exports && "object" == typeof module
+        ? module.exports = t()
+        : "function" == typeof define && define.amd
+        ? define([], t)
+        : "object" == typeof exports
+        ? exports.xmtp = t()
+        : e.xmtp = t();
+    }(this, () =>
+      (() => {
+        "use strict";
+        var e = {};
+        return (() => {
+          "use strict";
+          var t = e;
+          Object.defineProperty(t, "__esModule", { value: !0 }),
+            t.named2 = t.named1 = void 0,
+            t.named1 = "named-export-1",
+            t.named2 = "named-export-2",
+            t.default = "default-export";
+        })(),
+          e;
+      })());    
+    "#;
+    let swc = SWC::parse("index.cjs", source).expect("could not parse module");
+    let (exports, _) = swc
+      .parse_cjs_exports("production", true)
+      .expect("could not parse exports");
+    assert_eq!(exports.join(","), "__esModule,named2,named1,default");
+  }
+
+  #[test]
   fn parse_cjs_exports_case_22() {
     let source = r#"
       var url = module.exports = {};


### PR DESCRIPTION
Following up on https://twitter.com/lewisl9029/status/1674890868661325829, here's an early version of the PR for detecting minified UMD exports in esm-cjs-lexer. :)

Unfortunately, a lot of the code in here ended up looking rather nasty. I'm still pretty new to Rust, so would love to get some tips from someone more experienced on how the code could be improved! Happy to iterate on the code until you're happy with it.

I've added a number of minimal test cases representing some of the minified UMD patterns I've encountered in the wild (some from webpack, some from rollup). I'm sure there will be more, will tackle them as they come up, feel free to ping me in issues if you see any new cases that needs to be covered going forward!

I've been testing it out in prod by publishing it to this fork: https://www.npmjs.com/package/@lewisl9029/esm-cjs-lexer

And it seems to be working well so far, albeit maybe a bit slower (though I haven't done any benchmarks yet, please do let me know if you notice any performance footguns in here as well!). Feel free to take it for a spin when you have the chance and share your findings. Cheers!