### PR TITLE
Fix import from GitHub example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ esm.sh supports to import modules/assets from a github repo:
 `/gh/OWNER/REPO[@TAG]/PATH`. For example:
 
 ```js
-import tslib from "https://esm.sh/gh/microsoft/tslib@2.5.0";
+import tslib from "https://esm.sh/gh/microsoft/tslib@2.6.0";
 ```
 
 or load a svg image from a github repo:


### PR DESCRIPTION
![CleanShot 2023-08-16 at 19 15 24@2x](https://github.com/esm-dev/esm.sh/assets/5693018/17ae3916-c56c-4782-bda5-aa12e305b6e4)

The GitHub example isn't working because default exports were added to `tslib` just recently: https://github.com/microsoft/tslib/commit/a0a67d9bf5ac773982e079aec626b9d6ff2060f6 so I upgraded to 2.6.0.

I could also change it to something like:
```typescript
import * as tslib from "https://esm.sh/gh/microsoft/tslib@2.5.0";
```
but I think it's less desirable.


I love esm.sh BTW
