### PR TITLE
add setMaxListeners to events polyfill

### DIFF
--- a/server/embed/polyfills/node_events.js
+++ b/server/embed/polyfills/node_events.js
@@ -547,8 +547,31 @@ function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
   }
 }
 
+function setMaxListeners (n = defaultMaxListeners, ...eventTargets) {
+  if (typeof n !== "number" || n < 0 || NumberIsNaN(n)) {
+    throw new RangeError(
+      'The value of "n" is out of range. It must be a non-negative number. Received ' +
+        n + ".",
+    );
+  }
+  
+  if (eventTargets.length === 0) {
+    defaultMaxListeners = n;
+  } else {
+    for (let i = 0; i < eventTargets.length; i++) {
+      const target = eventTargets[i];
+      if (typeof target.setMaxListeners === 'function') {
+        target.setMaxListeners(n);
+      } else {
+        throw new TypeError(`eventTarget is invalid, must have 'setMaxListeners' method.`);
+      }
+    }
+  }
+};
+
 export {
   defaultMaxListeners,
+  setMaxListeners,
   EventEmitter,
   EventEmitter as default,
   init,


### PR DESCRIPTION
Hey there, great project, I'm loving using esm.sh :)

I recently ran into a blocker trying to import ipfs/helia via esm.sh: the esm.sh `events` polyfill does not export `setMaxListeners` so the thing broke rather violently. 

this is mostly just copypasta from the core nodejs events src. I see the rest of the polyfill still carries the joyent copyright notice so I assume that's where it came from too. 

I substituted the arg validation from the esm.sh setMaxListener function and removed the node internal eventTarget checking function in favor of simply ducktyping event targets by checking if they have a `setMaxListener` function (this is the second line of defense in the nodejs code). and substituted nodes internal error factory with simply throwing a `TypeError` with a helpful message.

Hope this is helpful. I don't have the time to setup the whole esm stack locally so unfortunately this is untested. Just figured I'd offer a solution to my problem rather than badger y'all to fix it for me. 

If for any reason `setMaxListeners` is excluded on purpose, or this isn't an acceptable solution. does anyone have suggestions on how I would solve my problem? I tried aliasing `events` to a local file. More generally, is there any way to do cjs export declarations on nested dependencies? Happy to start and participate on a more general solution to this type of problem on another thread. 

Cheers.