### PR TITLE
Add ?raw to support requests for raw package source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,25 +209,6 @@ const worker = workerFactory(workerAddon);
 
 This only works when the package **imports CSS files in JS** directly.
 
-### Raw source files
-
-In rare cases, you may want to request JS source files from packages, as-is,
-without transformation into ES modules. To do so, you need to add a `?raw`
-query to the request URL:
-
-```js
-await navigator.serviceWorker.register(
-  new URL(
-    "https://esm.sh/playground-elements@0.18.1/playground-service-worker.js?raw", 
-    import.meta.url.href
-  ), 
-  { scope: '/' }
-);
-```
-
-For example, you might need to register a package's source script as a service 
-worker in a browser that does not yet support the new `type: "module"` option.
-
 ### Importing WASM Modules
 
 esm.sh supports importing wasm modules in JS directly, to do that, you need to
@@ -300,6 +281,35 @@ package version.
 
 > esm.sh also provides a [CLI Script](#using-cli-script) in Deno to generate and
 > update the import maps that resolves dependencies automatically.
+
+### Escape Hatch: Raw Source Files
+
+In rare cases, you may want to request JS source files from packages, as-is,
+without transformation into ES modules. To do so, you need to add a `?raw`
+query to the request URL.
+
+For example, you might need to register a package's source script as a service worker
+in a browser that [does not yet support](https://caniuse.com/mdn-api_serviceworker_ecmascript_modules) 
+the `type: "module"` option:
+
+```js
+await navigator.serviceWorker.register(
+  new URL(
+    "https://esm.sh/playground-elements@0.18.1/playground-service-worker.js?raw", 
+    import.meta.url.href
+  ), 
+  { scope: '/' }
+);
+```
+
+You may alternatively specify an `&raw` extra query after the package version:
+
+```html
+<playground-project sandbox-base-url="https://esm.sh/playground-elements@0.18.1&raw/"
+></playground-project>
+```
+
+so that transitive references in the raw assets will also be raw requests.
 
 ## Deno Compatibility
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,25 @@ const worker = workerFactory(workerAddon);
 
 This only works when the package **imports CSS files in JS** directly.
 
+### Raw source files
+
+In rare cases, you may want to request JS source files from packages, as-is,
+without transformation into ES modules. To do so, you need to add a `?raw`
+query to the request URL:
+
+```js
+await navigator.serviceWorker.register(
+  new URL(
+    "https://esm.sh/playground-elements@0.18.1/playground-service-worker.js?raw", 
+    import.meta.url.href
+  ), 
+  { scope: '/' }
+);
+```
+
+For example, you might need to register a package's source script as a service 
+worker in a browser that does not yet support the new `type: "module"` option.
+
 ### Importing WASM Modules
 
 esm.sh supports importing wasm modules in JS directly, to do that, you need to

--- a/packages/esm-worker/src/index.ts
+++ b/packages/esm-worker/src/index.ts
@@ -648,6 +648,7 @@ async function fetchESM(
   const KV = Reflect.get(env, "KV") as KVNamespace | undefined ?? asKV(storage);
   const noStore = req.headers.has("X-Real-Origin");
   const isModule = !(
+    ctx.url.searchParams.has('raw') ||
     pathname.endsWith(".d.ts") ||
     pathname.endsWith(".d.mts") ||
     pathname.endsWith(".map")

--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -725,7 +725,7 @@ func esmHandler() rex.Handle {
 						return rex.Redirect(url, http.StatusMovedPermanently)
 					}
 					reqType = "types"
-				} else if ctx.Form.Has("raw") {
+				} else if ctx.R.URL.Query().Has("raw") {
 					reqType = "raw"
 				} else if hasBuildVerPrefix && hasTargetSegment(reqPkg.Subpath) {
 					reqType = "builds"

--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -804,6 +804,11 @@ func esmHandler() rex.Handle {
 				return rex.Status(404, "File Not Found")
 			}
 			header.Set("Cache-Control", "public, max-age=31536000, immutable")
+			if endsWith(savePath, ".js", ".mjs", ".jsx") {
+				header.Set("Content-Type", "application/javascript; charset=utf-8")
+			} else if endsWith(savePath, ".ts", ".mts", ".tsx") {
+				header.Set("Content-Type", "application/typescript; charset=utf-8")
+			}
 			return rex.Content(savePath, fi.ModTime(), content) // auto closed
 		}
 

--- a/server/server_handler.go
+++ b/server/server_handler.go
@@ -725,6 +725,8 @@ func esmHandler() rex.Handle {
 						return rex.Redirect(url, http.StatusMovedPermanently)
 					}
 					reqType = "types"
+				} else if ctx.Form.Has("raw") {
+					reqType = "raw"
 				} else if hasBuildVerPrefix && hasTargetSegment(reqPkg.Subpath) {
 					reqType = "builds"
 				}

--- a/test/esm-worker/esm-worker.test.ts
+++ b/test/esm-worker/esm-worker.test.ts
@@ -285,6 +285,22 @@ Deno.test("esm-worker", {
     assertEquals(pkgJson.name, "react");
   });
 
+  await t.step("npm assets (raw)", async () => {
+    const res = await fetch(
+      `${workerOrigin}/playground-elements@0.18.1&raw/playground-service-worker.js`
+    );
+    assertEquals(res.status, 200);
+    assertEquals(
+      res.headers.get("Content-Type"),
+      "application/javascript; charset=utf-8",
+    );
+    assertEquals(
+      res.headers.get("Cache-Control"),
+      "public, max-age=31536000, immutable",
+    );
+    assertStringIncludes(await res.text(), "!function(){");
+  });
+
   await t.step("gh modules", async () => {
     const res = await fetch(`${workerOrigin}/gh/microsoft/tslib`, {
       redirect: "manual",

--- a/test/raw/raw.test.ts
+++ b/test/raw/raw.test.ts
@@ -1,0 +1,14 @@
+import {
+    assertEquals,
+    assertStringIncludes,
+  } from "https://deno.land/std@0.180.0/testing/asserts.ts";
+  
+  Deno.test("raw untransformed JS", async () => {
+    const res = await fetch(
+      "http://localhost:8080/playground-elements@0.18.1/playground-service-worker.js?raw",
+    );
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get("content-type"), "application/javascript");
+    assertStringIncludes(await res.text(), "!function(){");
+  });
+  

--- a/test/raw/raw.test.ts
+++ b/test/raw/raw.test.ts
@@ -3,9 +3,18 @@ import {
     assertStringIncludes,
   } from "https://deno.land/std@0.180.0/testing/asserts.ts";
   
-  Deno.test("raw untransformed JS", async () => {
+  Deno.test("raw untransformed JS via ?raw query", async () => {
     const res = await fetch(
       "http://localhost:8080/playground-elements@0.18.1/playground-service-worker.js?raw",
+    );
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get("content-type"), "application/javascript");
+    assertStringIncludes(await res.text(), "!function(){");
+  });
+
+  Deno.test("raw untransformed JS via &raw extra query", async () => {
+    const res = await fetch(
+      "http://localhost:8080/playground-elements@0.18.1&raw/playground-service-worker.js",
     );
     assertEquals(res.status, 200);
     assertEquals(res.headers.get("content-type"), "application/javascript");

--- a/test/raw/raw.test.ts
+++ b/test/raw/raw.test.ts
@@ -8,7 +8,7 @@ import {
       "http://localhost:8080/playground-elements@0.18.1/playground-service-worker.js?raw",
     );
     assertEquals(res.status, 200);
-    assertEquals(res.headers.get("content-type"), "application/javascript");
+    assertEquals(res.headers.get("content-type"), "application/javascript; charset=utf-8");
     assertStringIncludes(await res.text(), "!function(){");
   });
 
@@ -17,7 +17,7 @@ import {
       "http://localhost:8080/playground-elements@0.18.1&raw/playground-service-worker.js",
     );
     assertEquals(res.status, 200);
-    assertEquals(res.headers.get("content-type"), "application/javascript");
+    assertEquals(res.headers.get("content-type"), "application/javascript; charset=utf-8");
     assertStringIncludes(await res.text(), "!function(){");
   });
   


### PR DESCRIPTION
As a followup to a Discord discussion, this PR adds an escape hatch via a new `?raw` query (and extra query) to allow requests for raw (untransformed) package source files.

In rare cases, you may want to request JS source files from packages, as-is, without transformation into ES modules. To do so, you would now add a `?raw` query to the request URL.

For example, you might need to register a package's source script as a service worker in a browser that [does not yet support](https://caniuse.com/mdn-api_serviceworker_ecmascript_modules) the `type: "module"` option:

```js
await navigator.serviceWorker.register(
  new URL(
    "https://esm.sh/playground-elements@0.18.1/playground-service-worker.js?raw", 
    import.meta.url.href
  ), 
  { scope: '/' }
);
```

You could also now alternatively specify an `&raw` extra query after the package version:

```html
<playground-project sandbox-base-url="https://esm.sh/playground-elements@0.18.1&raw/"
></playground-project>
```

so that transitive references in raw assets will also be raw requests.

(i.e. where an existing HTML package asset you request needs to subsequently request and receive a raw .js package asset)

As a concrete example benefit of this change, this new feature enables ESM.sh (or a self-hosted instance of ESM.sh with private nom repository) to be used like `unpkg.com` (the default) as the sandbox base URL for [Google Playground Elements](https://github.com/google/playground-elements).
