### PR TITLE
Improved Deno CLI

### DIFF
--- a/CLI.deno.ts
+++ b/CLI.deno.ts
@@ -505,9 +505,6 @@ if (import.meta.main) {
     else {
       imFilename = "deno.json";
     }
-    if (typeof config?.fmt?.options?.indentWidth === "number") {
-      indentWidth = config.fmt.options.indentWidth;
-    }
     await commands[command as keyof typeof commands](...parseFlags(args));
     console.log(`✨ Done in ${(performance.now() - start).toFixed(2)}ms`);
   } catch (error) {


### PR DESCRIPTION
I wanted to use the esm.sh CLI but noticed it had a few issues, so I decided to try and fix them myself.
- It can now use the `imports` property directly in `deno.json`, which has been the go-to for many since it has been introduced in Deno v1.30 (it should still support external import maps from my testing)
- It now uses `deno fmt` instead of forcing 2 space indent