### PR TITLE
Detect minified umd with leading fn declarations

### DIFF
--- a/packages/esm-cjs-lexer/src/cjs.rs
+++ b/packages/esm-cjs-lexer/src/cjs.rs
@@ -603,7 +603,7 @@ impl CJSLexer {
   }
 
   fn get_webpack_exports(&mut self, stmts: &Vec<Stmt>, webpack_require_sym: &str, first_stmt_index: &usize) {
-    stmts.iter().skip(first_stmt_index + 1).take(8).find(|stmt| match stmt {
+    stmts.iter().skip(*first_stmt_index).take(8).find(|stmt| match stmt {
       Stmt::Expr(ExprStmt { expr, .. }) => {
         if let Expr::Seq(SeqExpr { exprs, .. }) = &**expr {
           let mut found_webpack_require_exprs = false;
@@ -1335,7 +1335,7 @@ impl CJSLexer {
                                 let webpack_require_props = self.get_webpack_require_props_from_props(props);
 
                                 if webpack_require_props == 2 {
-                                  self.get_webpack_exports(stmts, &webpack_require_sym, &first_stmt_index);
+                                  self.get_webpack_exports(stmts, &webpack_require_sym, &(first_stmt_index + 1));
                                 }
                               }
                             }
@@ -1365,7 +1365,7 @@ impl CJSLexer {
                                 let webpack_require_props = self.get_webpack_require_props_from_props(props);
 
                                 if webpack_require_props == 2 {
-                                  self.get_webpack_exports(stmts, &webpack_require_sym, &first_stmt_index);
+                                  self.get_webpack_exports(stmts, &webpack_require_sym, &(first_stmt_index + 1));
                                 }
                               }
                             }
@@ -1392,58 +1392,7 @@ impl CJSLexer {
                               if let Some(expr) = exprs.get(0) {
                                 if let Expr::Call(call) = &**expr {
                                   if let Some(stmts) = is_iife_call(call) {
-                                    stmts.iter().take(8).find(|stmt| match stmt {
-                                      Stmt::Expr(ExprStmt { expr, .. }) => {
-                                        if let Expr::Seq(SeqExpr { exprs, .. }) = &**expr {
-                                          let mut found_webpack_require_exprs = false;
-                                          for expr in exprs {
-                                            if let Expr::Call(call) = &**expr {
-                                              if let Some(Expr::Member(MemberExpr { obj, prop, .. })) =
-                                                with_expr_callee(call)
-                                              {
-                                                if let (
-                                                  Expr::Ident(Ident { sym: obj_sym, .. }),
-                                                  MemberProp::Ident(Ident { sym: prop_sym, .. }),
-                                                ) = (&**obj, &*prop)
-                                                {
-                                                  if !obj_sym.as_ref().eq(webpack_require_sym) {
-                                                    return false;
-                                                  }
-                                                  let prop_sym_ref = prop_sym.as_ref();
-
-                                                  if prop_sym_ref.eq("r") {
-                                                    self.exports.insert("__esModule".to_string());
-                                                    found_webpack_require_exprs = true;
-                                                  }
-                                                  if prop_sym_ref.eq("d") {
-                                                    let CallExpr { args, .. } = &*call;
-                                                    if let Some(ExprOrSpread { expr, .. }) = args.get(1) {
-                                                      if let Expr::Object(ObjectLit { props, .. }) = &**expr {
-                                                        for prop in props {
-                                                          if let PropOrSpread::Prop(prop) = prop {
-                                                            if let Prop::KeyValue(KeyValueProp {
-                                                              key: PropName::Ident(Ident { sym, .. }),
-                                                              ..
-                                                            }) = &**prop
-                                                            {
-                                                              self.exports.insert(sym.as_ref().to_string());
-                                                              found_webpack_require_exprs = true;
-                                                            }
-                                                          }
-                                                        }
-                                                      }
-                                                    }
-                                                  }
-                                                }
-                                              }
-                                            }
-                                          }
-                                          return found_webpack_require_exprs;
-                                        }
-                                        return false;
-                                      }
-                                      _ => false,
-                                    });
+                                    self.get_webpack_exports(&stmts, &webpack_require_sym, &0);
                                   }
                                 }
                               }

--- a/packages/esm-cjs-lexer/src/cjs.rs
+++ b/packages/esm-cjs-lexer/src/cjs.rs
@@ -1200,7 +1200,7 @@ impl CJSLexer {
                                 }
 
                                 if webpack_require_props == 2 {
-                                  stmts.iter().skip(first_stmt_index + 1).find(|stmt| match stmt {
+                                  stmts.iter().skip(first_stmt_index + 1).take(8).find(|stmt| match stmt {
                                     Stmt::Expr(ExprStmt { expr, .. }) => {
                                       if let Expr::Seq(SeqExpr { exprs, .. }) = &**expr {
                                         let mut found_webpack_require_exprs = false;
@@ -1298,7 +1298,7 @@ impl CJSLexer {
                                 }
 
                                 if webpack_require_props == 2 {
-                                  stmts.iter().skip(first_stmt_index + 1).find(|stmt| match stmt {
+                                  stmts.iter().skip(first_stmt_index + 1).take(8).find(|stmt| match stmt {
                                     Stmt::Expr(ExprStmt { expr, .. }) => {
                                       if let Expr::Seq(SeqExpr { exprs, .. }) = &**expr {
                                         let mut found_webpack_require_exprs = false;
@@ -1440,7 +1440,7 @@ impl CJSLexer {
                               if let Some(expr) = exprs.get(0) {
                                 if let Expr::Call(call) = &**expr {
                                   if let Some(stmts) = is_iife_call(call) {
-                                    stmts.iter().find(|stmt| match stmt {
+                                    stmts.iter().take(8).find(|stmt| match stmt {
                                       Stmt::Expr(ExprStmt { expr, .. }) => {
                                         if let Expr::Seq(SeqExpr { exprs, .. }) = &**expr {
                                           let mut found_webpack_require_exprs = false;

--- a/packages/esm-cjs-lexer/src/test.rs
+++ b/packages/esm-cjs-lexer/src/test.rs
@@ -1274,6 +1274,91 @@ mod tests {
   }
 
   #[test]
+  fn parse_cjs_exports_case_21_11() {
+    // Webpack 5 minified UMD output from https://github.com/OfficeDev/microsoft-teams-library-js/blob/b5ee6475a7ed333cdb27f25fc51e5bb1ebd0da94/packages/teams-js/src/index.ts#L1
+    // with irrelevant parts manually removed.
+    // with umdNamedDefine: true: https://webpack.js.org/configuration/output/#outputlibraryumdnameddefine
+    // Formatted with Deno to avoid ast changes from prettier.
+    let source = r#"
+    !function (e, t) {
+      "object" == typeof exports && "object" == typeof module
+        ? module.exports = t()
+        : "function" == typeof define && define.amd
+        ? define("microsoftTeams", [], t)
+        : "object" == typeof exports
+        ? exports.microsoftTeams = t()
+        : e.microsoftTeams = t();
+    }("undefined" != typeof self ? self : this, () =>
+      (() => {
+        var e = {
+            302: (e, t, n) => {
+            },
+            65: (e, t, n) => {},
+            247: (e) => {},
+          },
+          t = {};
+        function n(o) {
+          var i = t[o];
+          if (void 0 !== i) return i.exports;
+          var r = t[o] = { exports: {} };
+          return e[o](r, r.exports, n), r.exports;
+        }
+        (() => {
+          var e,
+            t = Object.getPrototypeOf
+              ? (e) => Object.getPrototypeOf(e)
+              : (e) => e.__proto__;
+          n.t = function (o, i) {
+            if (1 & i && (o = this(o)), 8 & i) return o;
+            if ("object" == typeof o && o) {
+              if (4 & i && o.__esModule) return o;
+              if (16 & i && "function" == typeof o.then) return o;
+            }
+            var r = Object.create(null);
+            n.r(r);
+            var a = {};
+            e = e || [null, t({}), t([]), t(t)];
+            for (
+              var s = 2 & i && o; "object" == typeof s && !~e.indexOf(s); s = t(s)
+            ) Object.getOwnPropertyNames(s).forEach((e) => a[e] = () => o[e]);
+            return a.default = () => o, n.d(r, a), r;
+          };
+        })(),
+          (() => {
+            n.d = (e, t) => {
+              for (var o in t) {n.o(t, o) && !n.o(e, o) &&
+                  Object.defineProperty(e, o, { enumerable: !0, get: t[o] });}
+            };
+          })(),
+          (() => {
+            n.o = (e, t) => Object.prototype.hasOwnProperty.call(e, t);
+          })(),
+          (() => {
+            n.r = (e) => {
+              "undefined" != typeof Symbol && Symbol.toStringTag &&
+              Object.defineProperty(e, Symbol.toStringTag, { value: "Module" }),
+                Object.defineProperty(e, "__esModule", { value: !0 });
+            };
+          })();
+        var o = {};
+        return (() => {
+          "use strict";
+          n.r(o),
+            n.d(o, {
+              app: () => pt,
+            });
+        })(),
+          o;
+      })());    
+    "#;
+    let swc = SWC::parse("index.cjs", source).expect("could not parse module");
+    let (exports, _) = swc
+      .parse_cjs_exports("production", true)
+      .expect("could not parse exports");
+    assert_eq!(exports.join(","), "__esModule,app");
+  }
+
+  #[test]
   fn parse_cjs_exports_case_22() {
     let source = r#"
       var url = module.exports = {};

--- a/packages/esm-cjs-lexer/src/test.rs
+++ b/packages/esm-cjs-lexer/src/test.rs
@@ -1144,6 +1144,136 @@ mod tests {
   }
 
   #[test]
+  fn parse_cjs_exports_case_21_10() {
+    // Webpack 5 minified UMD output from https://github.com/ttag-org/ttag/blob/622c16c8e723a15916f4c5e0fcabefe3d3ad5f84/src/index.ts#L1
+    // with irrelevant parts manually removed.
+    // This ended up being subtly different from parse_cjs_exports_case_21_9, found out when I tried testing with the full original output.
+    // Formatted with Deno to avoid ast changes from prettier.
+    let source = r#"
+    !function (n, t) {
+      if ("object" == typeof exports && "object" == typeof module) {
+        module.exports = t();
+      } else if ("function" == typeof define && define.amd) define([], t);
+      else {
+        var e = t();
+        for (var r in e) ("object" == typeof exports ? exports : n)[r] = e[r];
+      }
+    }(this, () =>
+      (() => {
+        var n = {
+            44: (n, t) => {
+            },
+            429: (n, t, e) => {
+            },
+          },
+          t = {};
+        function e(r) {
+          var o = t[r];
+          if (void 0 !== o) return o.exports;
+          var f = t[r] = { exports: {} };
+          return n[r](f, f.exports, e), f.exports;
+        }
+        e.d = (n, t) => {
+          for (var r in t) {
+            e.o(t, r) && !e.o(n, r) &&
+              Object.defineProperty(n, r, { enumerable: !0, get: t[r] });
+          }
+        },
+          e.o = (n, t) => Object.prototype.hasOwnProperty.call(n, t),
+          e.r = (n) => {
+            "undefined" != typeof Symbol && Symbol.toStringTag &&
+            Object.defineProperty(n, Symbol.toStringTag, { value: "Module" }),
+              Object.defineProperty(n, "__esModule", { value: !0 });
+          };
+        var r = {};
+        return (() => {
+          "use strict";
+          function n(n, t) {
+            var e = Object.keys(n);
+            if (Object.getOwnPropertySymbols) {
+              var r = Object.getOwnPropertySymbols(n);
+              t && (r = r.filter(function (t) {
+                return Object.getOwnPropertyDescriptor(n, t).enumerable;
+              })), e.push.apply(e, r);
+            }
+            return e;
+          }
+          function t(t) {
+            for (var e = 1; e < arguments.length; e++) {
+              var r = null != arguments[e] ? arguments[e] : {};
+              e % 2
+                ? n(Object(r), !0).forEach(function (n) {
+                  o(t, n, r[n]);
+                })
+                : Object.getOwnPropertyDescriptors
+                ? Object.defineProperties(t, Object.getOwnPropertyDescriptors(r))
+                : n(Object(r)).forEach(function (n) {
+                  Object.defineProperty(
+                    t,
+                    n,
+                    Object.getOwnPropertyDescriptor(r, n),
+                  );
+                });
+            }
+            return t;
+          }
+          function o(n, t, e) {
+            return (t = function (n) {
+                var t = function (n, t) {
+                  if ("object" != typeof n || null === n) return n;
+                  var e = n[Symbol.toPrimitive];
+                  if (void 0 !== e) {
+                    var r = e.call(n, "string");
+                    if ("object" != typeof r) return r;
+                    throw new TypeError(
+                      "@@toPrimitive must return a primitive value.",
+                    );
+                  }
+                  return String(n);
+                }(n);
+                return "symbol" == typeof t ? t : String(t);
+              }(t)) in n
+              ? Object.defineProperty(n, t, {
+                value: e,
+                enumerable: !0,
+                configurable: !0,
+                writable: !0,
+              })
+              : n[t] = e,
+              n;
+          }
+          e.r(r),
+            e.d(r, {
+              Context: () => F,
+              TTag: () => H,
+              _: () => B,
+              addLocale: () => R,
+              c: () => q,
+              gettext: () => U,
+              jt: () => G,
+              msgid: () => N,
+              ngettext: () => J,
+              setDedent: () => K,
+              setDefaultLang: () => Q,
+              t: () => V,
+              useLocale: () => X,
+              useLocales: () => Y,
+            });
+        })(),
+          r;
+      })());
+    "#;
+    let swc = SWC::parse("index.cjs", source).expect("could not parse module");
+    let (exports, _) = swc
+      .parse_cjs_exports("production", true)
+      .expect("could not parse exports");
+    assert_eq!(
+      exports.join(","),
+      "__esModule,Context,TTag,_,addLocale,c,gettext,jt,msgid,ngettext,setDedent,setDefaultLang,t,useLocale,useLocales"
+    );
+  }
+
+  #[test]
   fn parse_cjs_exports_case_22() {
     let source = r#"
       var url = module.exports = {};


### PR DESCRIPTION
Hi there! This PR adds a fix for a minified UMD package ([ttag](https://www.npmjs.com/package/ttag)) that we didn't handle properly due to the hard-coded indices on statements inside the UMD fn body for detecting webpack's `.d` and `.r` calls.

You can repo by pasting this into the esm.sh playground:

```js
import * as ttag from "https://esm.sh/ttag";
console.log('ttag', ttag)
```

Note that we only see a default export even though the package has a whole bunch of named exports that we should be detecting.

This new implementation now uses some slightly smarter heuristics to determine indices in some places (skipping 1 index only if we detect "use strict"), and searches the entire list of statements until we find one that matches the expected shape in others. I added a few new test cases that fails with the previous implementation and succeeds with the current one.

I wrote this part of the code originally in https://github.com/esm-dev/esm.sh/pull/689, and tbh it still feels pretty nasty to work with... I'm still not familiar enough with idiomatic rust to know how to make things better yet. Would love to get some tips!