### PR TITLE
Fixing some windows issues - path slashes

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -184,7 +185,12 @@ func (ctx *BuildContext) install() (err error) {
 		ctx.wd = path.Join(ctx.npmrc.Dir(), ctx.pkg.Fullname())
 		ctx.pkgDir = path.Join(ctx.wd, "node_modules", ctx.pkg.Name)
 		if rp, e := os.Readlink(ctx.pkgDir); e == nil {
+			rp = MakePathOsAgnostic(rp)
+			if filepath.IsAbs(rp) {
+				ctx.pnpmPkgDir = rp
+			} else {
 			ctx.pnpmPkgDir = path.Join(path.Dir(ctx.pkgDir), rp)
+			}
 		} else {
 			ctx.pnpmPkgDir = ctx.pkgDir
 		}

--- a/server/config.go
+++ b/server/config.go
@@ -73,12 +73,13 @@ func LoadConfig(filename string) (cfg *Config, err error) {
 		if err != nil {
 			return nil, fmt.Errorf("fail to get current user home directory: %w", err)
 		}
-		cfg.WorkDir = path.Join(homeDir, ".esmd")
+		cfg.WorkDir = path.Join(MakePathOsAgnostic(homeDir), ".esmd")
 	} else {
-		cfg.WorkDir, err = filepath.Abs(cfg.WorkDir)
+		absWorkingDir, err := filepath.Abs(cfg.WorkDir)
 		if err != nil {
 			return nil, fmt.Errorf("fail to get absolute path of the work directory: %w", err)
 		}
+		cfg.WorkDir = absWorkingDir
 	}
 	return fixConfig(cfg), nil
 }
@@ -89,7 +90,7 @@ func DefaultConfig() *Config {
 		panic(err)
 	}
 	return fixConfig(&Config{
-		WorkDir: path.Join(homeDir, ".esmd"),
+		WorkDir: path.Join(MakePathOsAgnostic(homeDir), ".esmd"),
 	})
 }
 

--- a/server/path_utils.go
+++ b/server/path_utils.go
@@ -1,0 +1,15 @@
+package server
+
+import (
+	"os"
+	"strings"
+)
+
+// MakePathOsAgnostic makes the given path OS agnostic by replacing backslashes with forward slashes.
+func MakePathOsAgnostic(path string) string {
+	if os.PathSeparator == '\\' {
+		return strings.ReplaceAll(path, "\\", "/")
+	}
+
+	return path
+}


### PR DESCRIPTION
Was trying to run the project in windows and it had made some really funky paths.

1: some paths had mixed back and forward slashes
2: some paths were incorrectly concatenated, like `C:/Users/frtn/.esmd/npm/react@18.3.1/node_modules/C:/Users/frtn/.esmd/npm/react@18.3.1/node_modules/.pnpm/react@18.3.1/node_modules/react`

Trying to fix both in here.

Tested only in my windows computer and things seem to work well with a few packages I tried, so you may need to test it yourself before merging for the other OSs to make sure I didn't break them 😅 