### PR TITLE
fix/improve npm polyfills

### DIFF
--- a/server/embed/polyfills/npm/has-proto.mjs
+++ b/server/embed/polyfills/npm/has-proto.mjs
@@ -1,3 +1,1 @@
-const foo={bar:{}};
-const O=Object;
-export default ()=>({__proto__:foo}).bar===foo.bar&&!({__proto__:null}instanceof O);
+export default ()=>true;

--- a/server/embed/polyfills/npm/has-tostringtag.mjs
+++ b/server/embed/polyfills/npm/has-tostringtag.mjs
@@ -1,1 +1,1 @@
-export default ()=>typeof Symbol.toStringTag==="symbol";
+export default ()=>true;


### PR DESCRIPTION
- remove inaccurate **define-properties.mjs** in https://github.com/esm-dev/esm.sh/commit/7cf5e049656034612e9f937efb95ea147878add3
- `has-proto` →  `()=>true`
- `has-tostringtag` →  `()=>true`