### PR TITLE
Remove 'Access-Control-Allow-Methods' header

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/ije/esbuild-internal v0.24.0
 	github.com/ije/gox v0.9.1
-	github.com/ije/rex v1.13.7
+	github.com/ije/rex v1.13.8
 	github.com/yuin/goldmark v1.7.8
 	github.com/yuin/goldmark-meta v1.1.0
 	golang.org/x/net v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/ije/esbuild-internal v0.24.0 h1:ekQilnTP0YQBpqHwaZwpIWH/YbehY4xctKW8g
 github.com/ije/esbuild-internal v0.24.0/go.mod h1:s7HvKZ4ZGifyzvgWpSwnJOQTr6b+bsgfNBZ8HAEwwSM=
 github.com/ije/gox v0.9.1 h1:w+hVBqo/e8+g1VUxfikHlIJrcevHhB6WswvPzpGO0w4=
 github.com/ije/gox v0.9.1/go.mod h1:3GTaK8WXf6oxRbrViLqKNLTNcMR871Dz0zoujFNmG48=
-github.com/ije/rex v1.13.7 h1:8K2LyED+GB2+cxPcOGXJ+Ptyw+xfI6UNNg05SlTjEG8=
-github.com/ije/rex v1.13.7/go.mod h1:81UCOz0rEwIjgKFwzRlEjMJcB9BtJSOs0v8k9p5z4lY=
+github.com/ije/rex v1.13.8 h1:O6JVXaTPaPgCZWN5PtzPTPEFeIJvOcd4893WcnjfPrU=
+github.com/ije/rex v1.13.8/go.mod h1:81UCOz0rEwIjgKFwzRlEjMJcB9BtJSOs0v8k9p5z4lY=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
 github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=

--- a/server/server.go
+++ b/server/server.go
@@ -177,7 +177,7 @@ func cors(allowOrigins []string) rex.Handle {
 			setCorsHeaders(h, isOptionsMethod, "*")
 		}
 		if isOptionsMethod {
-			return rex.Status(204, nil)
+			return rex.NoContent()
 		}
 		return nil
 	}
@@ -185,11 +185,8 @@ func cors(allowOrigins []string) rex.Handle {
 
 func setCorsHeaders(h http.Header, isOptionsMethod bool, origin string) {
 	h.Set("Access-Control-Allow-Origin", origin)
-	h.Set("Access-Control-Allow-Methods", "HEAD, GET, POST")
 	if isOptionsMethod {
 		h.Set("Access-Control-Allow-Headers", "*")
 		h.Set("Access-Control-Max-Age", "86400")
-	} else {
-		h.Set("Access-Control-Expose-Headers", "X-Esm-Path, X-Typescript-Types")
 	}
 }

--- a/test/cors/cors.test.ts
+++ b/test/cors/cors.test.ts
@@ -6,7 +6,6 @@ Deno.test("CORS", async () => {
     res.body?.cancel();
     assertEquals(res.status, 204);
     assertEquals(res.headers.get("Access-Control-Allow-Origin"), "*");
-    assertEquals(res.headers.get("Access-Control-Allow-Methods"), "HEAD, GET, POST");
     assertEquals(res.headers.get("Access-Control-Allow-Headers"), "*");
     assertEquals(res.headers.get("Access-Control-Max-Age"), "86400");
   }
@@ -14,8 +13,14 @@ Deno.test("CORS", async () => {
     const res = await fetch("http://localhost:8080/react@18.2.0");
     res.body?.cancel();
     assertEquals(res.headers.get("Access-Control-Allow-Origin"), "*");
-    assertEquals(res.headers.get("Access-Control-Allow-Methods"), "HEAD, GET, POST");
-    assertEquals(res.headers.get("Access-Control-Expose-Headers"), "X-Esm-Path, X-Typescript-Types");
+    assertEquals(res.headers.get("Access-Control-Expose-Headers"), "X-ESM-Path, X-TypeScript-Types");
+    assertEquals(res.headers.get("Vary"), "User-Agent");
+  }
+  {
+    const res = await fetch("http://localhost:8080/react@18.2.0?no-dts");
+    res.body?.cancel();
+    assertEquals(res.headers.get("Access-Control-Allow-Origin"), "*");
+    assertEquals(res.headers.get("Access-Control-Expose-Headers"), "X-ESM-Path");
     assertEquals(res.headers.get("Vary"), "User-Agent");
   }
   {
@@ -26,8 +31,7 @@ Deno.test("CORS", async () => {
     });
     res.body?.cancel();
     assertEquals(res.headers.get("Access-Control-Allow-Origin"), "*");
-    assertEquals(res.headers.get("Access-Control-Allow-Methods"), "HEAD, GET, POST");
-    assertEquals(res.headers.get("Access-Control-Expose-Headers"), "X-Esm-Path, X-Typescript-Types");
+    assertEquals(res.headers.get("Access-Control-Expose-Headers"), "X-ESM-Path, X-TypeScript-Types");
     assertEquals(res.headers.get("Vary"), "User-Agent");
   }
 });


### PR DESCRIPTION
the default "Access-Control-Allow-Methods" header is "GET, HEAD, POST", no need to set.
see https://www.w3.org/TR/2020/SPSD-cors-20200602/#simple-cross-origin-request-0