### PR TITLE
Add `?at=DATE` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ With [import maps](https://github.com/WICG/import-maps), you can even use bare i
   ```js
   // Examples
   import React from "https://esm.sh/react"; // latest
-  import React from "https://esm.sh/react@17"; // 17.0.2
+  import React from "https://esm.sh/react@18"; // 18.2.0
   import React from "https://esm.sh/react@beta"; // latest beta
   import { renderToString } from "https://esm.sh/react-dom/server"; // sub-modules
   ```
@@ -66,14 +66,31 @@ With [import maps](https://github.com/WICG/import-maps), you can even use bare i
   import { Bench } from "https://esm.sh/pr/tinybench@a832a55"; // --compact
   ```
 
-### Specifying Dependencies
+### Package Versioning
 
-By default, esm.sh rewrites import specifiers based on the package dependencies. To specify the version of these
-dependencies, you can add `?deps=PACKAGE@VERSION` to the import URL. To specify multiple dependencies, separate them with commas, like this: `?deps=react@17.0.2,react-dom@17.0.2`.
+esm.sh respects [semver](https://docs.npmjs.com/cli/v6/using-npm/semver) and [dist-tag](https://docs.npmjs.com/cli/v8/commands/npm-dist-tag) of NPM for resolving package versions. This means you can specify versions using semver ranges or dist-tags like `latest`, `beta`, etc.
 
 ```js
-import React from "https://esm.sh/react@17.0.2";
-import useSWR from "https://esm.sh/swr?deps=react@17.0.2";
+import React from "https://esm.sh/react" // latest
+import React from "https://esm.sh/react@19.0.0"
+import React from "https://esm.sh/react@^19.0.0"
+import React from "https://esm.sh/react@19"
+import React from "https://esm.sh/react@canary"
+```
+
+You can also fetch a package version closest to a given timestamp or date. This feature eliminates the need to know the exact version beforehand, similar to running `npm install <package>` without specifying a version. However, it still provides a fixed version for future installations, ensuring consistency. This is particularly useful for LLM-generated web applications, where maintaining the same package version across all instances is crucial.
+
+```js
+import React from "https://esm.sh/react?at=YYYY-MM-DD";
+import React from "https://esm.sh/react?at=TIMESTAMP";
+```
+
+By default, esm.sh rewrites import specifiers based on the `dependencies` field of `package.json`. To specify the version of these
+dependencies, you can add `?deps=PACKAGE@VERSION` to the import URL. To specify multiple dependencies, separate them with commas(`,`), like this: `?deps=react@19.0.0,react-dom@19.0.0`.
+
+```js
+import React from "https://esm.sh/react@19.0.0";
+import useSWR from "https://esm.sh/swr?deps=react@19.0.0";
 ```
 
 ### Aliasing Dependencies

--- a/server/build_args_test.go
+++ b/server/build_args_test.go
@@ -8,8 +8,9 @@ import (
 
 func TestEncodeBuildArgs(t *testing.T) {
 	conditions := []string{"react-server"}
-	buildArgsString := encodeBuildArgs(
+	code := encodeBuildArgs(
 		BuildArgs{
+			at:    1737515664,
 			alias: map[string]string{"a": "b"},
 			deps: map[string]string{
 				"c": "1.0.0",
@@ -24,29 +25,33 @@ func TestEncodeBuildArgs(t *testing.T) {
 		},
 		false,
 	)
-	args, err := decodeBuildArgs(buildArgsString)
+	args, err := decodeBuildArgs(code)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(args.alias) != 1 || args.alias["a"] != "b" {
-		t.Fatal("invalid alias")
+		t.Fatal("invalid `alias`")
 	}
 	if len(args.deps) != 3 {
-		t.Fatal("invalid deps")
+		t.Fatal("invalid `deps`")
 	}
 	if args.external.Len() != 2 {
-		t.Fatal("invalid external")
+		t.Fatal("invalid `external`")
 	}
 	if len(args.conditions) != 1 || args.conditions[0] != "react-server" {
-		t.Fatal("invalid conditions")
+		t.Fatal("invalid `conditions`")
+	}
+	if args.at != 1737515664 {
+		t.Fatal("invalid `since`")
 	}
 	if !args.externalRequire {
-		t.Fatal("ignoreRequire should be true")
+		t.Fatal("`ignoreRequire` should be true")
 	}
 	if !args.keepNames {
-		t.Fatal("keepNames should be true")
+		t.Fatal("`keepNames` should be true")
 	}
 	if !args.ignoreAnnotations {
-		t.Fatal("ignoreAnnotations should be true")
+		t.Fatal("`ignoreAnnotations` should be true")
 	}
+	t.Log("code:", code)
 }

--- a/server/router.go
+++ b/server/router.go
@@ -563,11 +563,11 @@ func esmRouter(db DB, buildStorage storage.Storage, logger *log.Logger) rex.Hand
 				if ctxParam == "" {
 					return rex.Status(400, "Missing `ctx` Param")
 				}
-				ctxPath, err := atobUrl(ctxParam)
+				ctxPath, err := base64.RawURLEncoding.DecodeString(ctxParam)
 				if err != nil {
 					return rex.Status(400, "Invalid `ctx` Param")
 				}
-				ctxUrlRaw := modUrl.Scheme + "://" + modUrl.Host + ctxPath
+				ctxUrlRaw := modUrl.Scheme + "://" + modUrl.Host + string(ctxPath)
 				ctxUrl, err := url.Parse(ctxUrlRaw)
 				if err != nil {
 					return rex.Status(400, "Invalid `ctx` Param")
@@ -721,11 +721,11 @@ func esmRouter(db DB, buildStorage storage.Storage, logger *log.Logger) rex.Hand
 				if err == storage.ErrNotFound {
 					importMap := common.ImportMap{}
 					if len(im) > 0 {
-						imPath, err := atobUrl(im)
+						imPath, err := base64.RawURLEncoding.DecodeString(im)
 						if err != nil {
 							return rex.Status(400, "Invalid `im` Param")
 						}
-						imUrl, err := url.Parse(modUrl.Scheme + "://" + modUrl.Host + imPath)
+						imUrl, err := url.Parse(modUrl.Scheme + "://" + modUrl.Host + string(imPath))
 						if err != nil {
 							return rex.Status(400, "Invalid `im` Param")
 						}
@@ -764,7 +764,8 @@ func esmRouter(db DB, buildStorage storage.Storage, logger *log.Logger) rex.Hand
 										if err != nil {
 											return rex.Status(400, "Invalid import map")
 										}
-										importMap.Src, _ = atobUrl(im)
+										data, _ := base64.RawURLEncoding.DecodeString(im)
+										importMap.Src = string(data)
 									}
 									break
 								}

--- a/server/utils.go
+++ b/server/utils.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"encoding/base64"
 	"errors"
 	"net/http"
 	"os"
@@ -124,7 +123,7 @@ func findFiles(root string, dir string, filter func(filename string) bool) ([]st
 		name := entry.Name()
 		filename := name
 		if dir != "" {
-			filename = dir + "/" + name
+			filename = join2(dir, '/', name)
 		}
 		if entry.IsDir() {
 			if name == "node_modules" {
@@ -147,18 +146,20 @@ func findFiles(root string, dir string, filter func(filename string) bool) ([]st
 	return files, nil
 }
 
-// btoaUrl converts a string to a base64 string.
-func btoaUrl(s string) string {
-	return base64.RawURLEncoding.EncodeToString([]byte(s))
+func join2(a string, c byte, b string) string {
+	buf := make([]byte, len(a)+1+len(b))
+	copy(buf, a)
+	buf[len(a)] = c
+	copy(buf[len(a)+1:], b)
+	return string(buf)
 }
 
-// atobUrl converts a base64 string to a string.
-func atobUrl(s string) (string, error) {
-	data, err := base64.RawURLEncoding.DecodeString(s)
-	if err != nil {
-		return "", err
-	}
-	return string(data), nil
+func join3(a string, b string, c string) string {
+	buf := make([]byte, len(a)+len(b)+len(c))
+	copy(buf, a)
+	copy(buf[len(a):], b)
+	copy(buf[len(b):], c)
+	return string(buf)
 }
 
 // appendVaryHeader appends the given key to the `Vary` header.
@@ -167,7 +168,7 @@ func appendVaryHeader(header http.Header, key string) {
 	if vary == "" {
 		header.Set("Vary", key)
 	} else {
-		header.Set("Vary", vary+", "+key)
+		header.Set("Vary", join3(vary, ", ", key))
 	}
 }
 


### PR DESCRIPTION
This pr allows uou to fetch a package version closest to a given timestamp or date. This feature eliminates the need to know the exact version beforehand, similar to running `npm install <package>` without specifying a version. However, it still provides a fixed version for future installations, ensuring consistency. This is particularly useful for LLM-generated web applications, where maintaining the same package version across all instances is crucial.

For example:

```js
import React from "https://esm.sh/react?at=YYYY-MM-DD";
import React from "https://esm.sh/react?at=TIMESTAMP";
```

implements #1047 