### PR TITLE
Fix legacy redirects

### DIFF
--- a/server/git.go
+++ b/server/git.go
@@ -62,7 +62,7 @@ func ghInstall(wd, name, tag string) (err error) {
 	if err != nil {
 		return
 	}
-	fetchClient, recycle := NewFetchClient(30, "esmd/"+VERSION)
+	fetchClient, recycle := NewFetchClient(30, "esmd/"+VERSION, false)
 	defer recycle()
 	res, err := fetchClient.Fetch(u, nil)
 	if err != nil {

--- a/server/legacy_router.go
+++ b/server/legacy_router.go
@@ -272,9 +272,11 @@ func legacyESM(ctx *rex.Context, buildStorage storage.Storage, buildVersionPrefi
 			return rex.Status(500, "Failed to fetch data from the legacy esm.sh server")
 		}
 		if endsWith(pathname, ".d.ts", ".d.mts") {
-			origin := getOrigin(ctx) + "/"
-			data = bytes.ReplaceAll(data, []byte("https://esm.sh/"), []byte(origin))
-			data = bytes.ReplaceAll(data, []byte("https://legacy.esm.sh/"), []byte(origin))
+			origin := getOrigin(ctx)
+			if origin != "https://esm.sh" {
+				data = bytes.ReplaceAll(data, []byte("https://esm.sh"), []byte(origin))
+			}
+			data = bytes.ReplaceAll(data, []byte(config.LegacyServer), []byte(origin))
 		}
 		err = buildStorage.Put(savePath, bytes.NewReader(data))
 		if err != nil {

--- a/server/npm.go
+++ b/server/npm.go
@@ -378,7 +378,7 @@ func (npmrc *NpmRC) getPackageInfo(pkgName string, version string) (packageJson 
 			header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(reg.User+":"+reg.Password)))
 		}
 
-		fetchClient, recycle := NewFetchClient(15, "esmd/"+VERSION)
+		fetchClient, recycle := NewFetchClient(15, "esmd/"+VERSION, false)
 		defer recycle()
 
 		retryTimes := 0
@@ -628,7 +628,7 @@ func fetchPackageTarball(reg *NpmRegistry, installDir string, pkgName string, ta
 		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(reg.User+":"+reg.Password)))
 	}
 
-	fetchClient, recycle := NewFetchClient(30, "esmd/"+VERSION)
+	fetchClient, recycle := NewFetchClient(30, "esmd/"+VERSION, false)
 	defer recycle()
 
 	retryTimes := 0

--- a/server/router.go
+++ b/server/router.go
@@ -240,7 +240,7 @@ func esmRouter(db DB, buildStorage storage.Storage, logger *log.Logger) rex.Hand
 			indexHTML, err := withCache("index.html", time.Duration(cacheTtl)*time.Second, func() (indexHTML []byte, _ string, err error) {
 				readme, err := os.ReadFile("README.md")
 				if err != nil {
-					fetchClient, recycle := NewFetchClient(15, ctx.UserAgent())
+					fetchClient, recycle := NewFetchClient(15, ctx.UserAgent(), false)
 					defer recycle()
 					readmeUrl, _ := url.Parse("https://raw.githubusercontent.com/esm-dev/esm.sh/refs/heads/main/README.md")
 					var res *http.Response
@@ -559,7 +559,7 @@ func esmRouter(db DB, buildStorage storage.Storage, logger *log.Logger) rex.Hand
 			if v != "" && (!npmVersioning.Match(v) || len(v) > 32) {
 				return rex.Status(400, "Invalid Version Param")
 			}
-			fetchClient, recycle := NewFetchClient(15, ctx.UserAgent())
+			fetchClient, recycle := NewFetchClient(15, ctx.UserAgent(), false)
 			defer recycle()
 			if strings.HasSuffix(modUrl.Path, "/uno.css") {
 				ctxParam := query.Get("ctx")

--- a/server/server.go
+++ b/server/server.go
@@ -196,7 +196,7 @@ func customLandingPage(options *LandingPageOptions) rex.Handle {
 			if err != nil {
 				return rex.Err(http.StatusBadRequest, "Invalid url")
 			}
-			fetchClient, recycle := NewFetchClient(15, ctx.UserAgent())
+			fetchClient, recycle := NewFetchClient(15, ctx.UserAgent(), false)
 			defer recycle()
 			res, err := fetchClient.Fetch(url, nil)
 			if err != nil {
@@ -222,8 +222,10 @@ func customLandingPage(options *LandingPageOptions) rex.Handle {
 					ctx.SetHeader("Last-Modified", lastModified)
 				}
 			}
-			cacheCache := res.Header.Get("Cache-Control")
-			if cacheCache == "" {
+			cacheControl := res.Header.Get("Cache-Control")
+			if cacheControl != "" {
+				ctx.SetHeader("Cache-Control", cacheControl)
+			} else {
 				ctx.SetHeader("Cache-Control", ccMustRevalidate)
 			}
 			ctx.SetHeader("Content-Type", res.Header.Get("Content-Type"))

--- a/test/legacy-routes/test.ts
+++ b/test/legacy-routes/test.ts
@@ -184,13 +184,13 @@ Deno.test("legacy routes", async () => {
     const res = await fetch("http://localhost:8080/v135/@types/react-dom@18.3.1/index.d.ts");
     assertEquals(res.status, 200);
     assertEquals(res.headers.get("Content-Type"), "application/typescript; charset=utf-8");
-    assertStringIncludes(await res.text(), "https://esm.sh/v135/@types/react@18.");
+    assertStringIncludes(await res.text(), "http://localhost:8080/v135/@types/react@18.");
   }
   {
     const res = await fetch("http://localhost:8080/v135/@types/react-modal@3.16.3/X-ZS8q/index.d.ts");
     assertEquals(res.status, 200);
     assertEquals(res.headers.get("Content-Type"), "application/typescript; charset=utf-8");
-    assertStringIncludes(await res.text(), "https://esm.sh/v135/@types/react@");
+    assertStringIncludes(await res.text(), "http://localhost:8080/v135/@types/react@");
   }
   {
     const res = await fetch("http://localhost:8080/v135/@types/react-dom@~18.3/client~.d.ts", {
@@ -245,5 +245,18 @@ Deno.test("legacy routes", async () => {
     });
     res.body?.cancel();
     assertEquals(res.status, 400);
+  }
+  {
+    // respect legacy redirects
+    const res = await fetch("http://localhost:8080/v135/@jitl/quickjs-ng-wasmfile-release-sync@0.31.0/es2022/emscripten-module.wasm", {
+      headers: { "User-Agent": "i'm a browser" },
+      redirect: "manual",
+    });
+    res.body?.cancel();
+    assertEquals(res.status, 301);
+    assertEquals(
+      res.headers.get("Location"),
+      "http://localhost:8080/@jitl/quickjs-ng-wasmfile-release-sync@0.31.0/dist/emscripten-module.wasm",
+    );
   }
 });


### PR DESCRIPTION

```
https://esm.sh/v135/@jitl/quickjs-ng-wasmfile-release-sync@0.31.0/es2022/emscripten-module.wasm -> https://esm.sh/@jitl/quickjs-ng-wasmfile-release-sync@0.31.0/dist/emscripten-module.wasm
```

close #1072