### PR TITLE
Use global `Buffer` and `process`

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -1153,7 +1153,10 @@ REBUILD:
 							} else if name, ok := ctx.pkgJson.Browser["node:process"]; ok {
 								excluded = name == ""
 							}
-							if !excluded {
+							if excluded {
+								header.WriteString(`const __Process$ = globalThis.process;`)
+								header.WriteByte('\n')
+							} else {
 								header.WriteString(`import __Process$ from "/node/process.mjs";`)
 								header.WriteByte('\n')
 								imports.Add("/node/process.mjs")
@@ -1184,7 +1187,10 @@ REBUILD:
 								excluded = name == ""
 							}
 						}
-						if !excluded {
+						if excluded {
+							header.WriteString(`const __Buffer$ = globalThis.Buffer;`)
+							header.WriteByte('\n')
+						} else {
 							header.WriteString(`import { Buffer as __Buffer$ } from "/node/buffer.mjs";`)
 							header.WriteByte('\n')
 							imports.Add("/node/buffer.mjs")

--- a/test/node-polyfill/browser-excluded.test.ts
+++ b/test/node-polyfill/browser-excluded.test.ts
@@ -1,0 +1,21 @@
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert";
+
+/**
+  `browser` field in package.json is used to exclude some node.js specific modules from the browser build.
+  ```json
+  {
+    "browser": {
+      "node:buffer": false
+    }
+  }
+  ```
+*/
+Deno.test("browser excluded node polyfill", async () => {
+  {
+    const res = await fetch("http://localhost:8080/cbor-x@1.6.0/es2022/cbor-x.mjs", {
+      headers: { "user-agent": "i'm a browser" },
+    });
+    assertEquals(res.status, 200);
+    assertStringIncludes(await res.text(), `const __Buffer$ = globalThis.Buffer;`);
+  }
+});

--- a/test/node-polyfill/polyfill.test.ts
+++ b/test/node-polyfill/polyfill.test.ts
@@ -1,0 +1,10 @@
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert";
+
+Deno.test("node polyfill", async () => {
+  {
+    const res = await fetch("http://localhost:8080/node/process.mjs");
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get("content-type"), "application/javascript; charset=utf-8");
+    assertStringIncludes(await res.text(), `exit:`);
+  }
+});


### PR DESCRIPTION
only when `browser` excluded:

```json
{
  "browser": {
    "node:buffer": false
  }
}
```