### PR TITLE
Call finalizeBuildEntry for exportEntries generated from asteriskPath objects

### DIFF
--- a/server/build_resolver.go
+++ b/server/build_resolver.go
@@ -174,6 +174,7 @@ func (ctx *BuildContext) resolveEntry(esm EsmPath) (entry BuildEntry) {
 							}
 							*/
 							exportEntry = ctx.resolveConditionExportEntry(resloveAsteriskPathMapping(obj, diff), pkgJson.Type)
+							ctx.finalizeBuildEntry(&exportEntry)
 							if !exportEntry.isEmpty() {
 								break
 							}

--- a/test/issue-1161/test.ts
+++ b/test/issue-1161/test.ts
@@ -1,0 +1,11 @@
+import { assert, assertEquals, assertStringIncludes } from "jsr:@std/assert";
+
+// change the import path to the module you want to test
+import {Client} from "http://localhost:8080/@modelcontextprotocol/sdk@1.15.0/client/index.js";
+
+// related issue: https://github.com/esm-dev/esm.sh/issues/1161
+Deno.test("testing name", async () => {
+  const client = new Client({name: 'test', version: '1.0.0'});
+  assert("connect" in client);
+  assertEquals(typeof client.connect, "function");
+});


### PR DESCRIPTION
Fixes #1161  and https://github.com/modelcontextprotocol/typescript-sdk/issues/293

Why?

MCP's package.json doesn't follow the expected values. It looks like:

```json
  "exports": {
    "./*": {
      "import": "./dist/esm/*",
      "require": "./dist/cjs/*"
    }
  },

```

But the code expects the values to include the extension.

This handles that by searching for the extension that is actually present (as happens in other cases)