### PR TITLE
Migration storage

### DIFF
--- a/config.example.jsonc
+++ b/config.example.jsonc
@@ -54,13 +54,6 @@
     "secretAccessKey": ""
   },
 
-  // Cache package raw files in the storage, default is false.
-  // The server cleans up npm store periodically, to avoid unnecessary installation when accessing
-  // package raw files, you can enable this option to cache package raw files in the storage.
-  // Note: this option will increase the storage usage, we recommend to enable it if you are using
-  // a S3-compatible storage.
-  "cacheRawFile": false,
-
   // The custom landing page options, default is empty.
   // The server will proxy the `/` request to the `origin` server if it's provided.
   // If your custom landing page has own assets, you also need to provide those asset paths in the `assets` field.

--- a/internal/storage/migration.go
+++ b/internal/storage/migration.go
@@ -1,0 +1,63 @@
+package storage
+
+import (
+	"errors"
+	"io"
+)
+
+// NewMigrationStorage creates a new storage instance that migrates files from one storage to another.
+// It first tries to get files from the front storage, and if not found, it retrieves them from the back storage.
+func NewMigrationStorage(frontStorage Storage, backStorage Storage) (storage Storage) {
+	return &migrationStorage{
+		front: frontStorage,
+		back:  backStorage,
+	}
+}
+
+type migrationStorage struct {
+	front Storage
+	back  Storage
+}
+
+func (m *migrationStorage) Stat(key string) (stat Stat, err error) {
+	stat, err = m.front.Stat(key)
+	if err == ErrNotFound {
+		stat, err = m.back.Stat(key)
+	}
+	return
+}
+
+func (m *migrationStorage) Get(key string) (content io.ReadCloser, stat Stat, err error) {
+	content, stat, err = m.front.Get(key)
+	if err == ErrNotFound {
+		content, stat, err = m.back.Get(key)
+		if err == nil {
+			pr, pw := io.Pipe()
+			go func(content io.ReadCloser) {
+				defer pw.Close()
+				defer content.Close()
+				m.front.Put(key, io.TeeReader(content, pw))
+			}(content)
+			content = pr
+		}
+	}
+	return
+}
+
+func (m *migrationStorage) List(prefix string) (keys []string, err error) {
+	return nil, errors.New("List operation is not supported in migration storage")
+}
+
+func (m *migrationStorage) Put(key string, content io.Reader) (err error) {
+	return m.front.Put(key, content)
+}
+
+func (m *migrationStorage) Delete(key string) (err error) {
+	m.back.Delete(key)
+	return m.front.Delete(key)
+}
+
+func (m *migrationStorage) DeleteAll(prefix string) (deletedKeys []string, err error) {
+	m.back.DeleteAll(prefix)
+	return m.front.DeleteAll(prefix)
+}

--- a/internal/storage/migration_test.go
+++ b/internal/storage/migration_test.go
@@ -1,0 +1,100 @@
+package storage
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/ije/gox/crypto/rand"
+)
+
+func TestMigrationStorage(t *testing.T) {
+	root1 := path.Join(os.TempDir(), "storage_test_"+rand.Hex.String(8))
+	back, err := NewFSStorage(&StorageOptions{Type: "fs", Endpoint: root1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root1)
+
+	root2 := path.Join(os.TempDir(), "storage_test_"+rand.Hex.String(8))
+	front, err := NewFSStorage(&StorageOptions{Type: "fs", Endpoint: root2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root2)
+
+	migrationStorage := NewMigrationStorage(front, back)
+
+	err = back.Put("foo.txt", bytes.NewBufferString("Hello, World!"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = front.Stat("foo.txt")
+	if err != ErrNotFound {
+		t.Fatal("Expected error, but got nil")
+	}
+
+	_, _, err = front.Get("foo.txt")
+	if err != ErrNotFound {
+		t.Fatal("Expected error, but got nil")
+	}
+
+	fi, err := migrationStorage.Stat("foo.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fi.Size() != 13 {
+		t.Fatalf("invalid file size(%d), shoud be 13", fi.Size())
+	}
+
+	f, fi, err := migrationStorage.Get("foo.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	if fi.Size() != 13 {
+		t.Fatalf("invalid file size(%d), shoud be 13", fi.Size())
+	}
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(data) != "Hello, World!" {
+		t.Fatalf("invalid file content('%s'), shoud be 'Hello, World!'", string(data))
+	}
+
+	fi, err = front.Stat("foo.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fi.Size() != 13 {
+		t.Fatalf("invalid file size(%d), shoud be 13", fi.Size())
+	}
+
+	f, fi, err = front.Get("foo.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	if fi.Size() != 13 {
+		t.Fatalf("invalid file size(%d), shoud be 13", fi.Size())
+	}
+
+	data, err = io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(data) != "Hello, World!" {
+		t.Fatalf("invalid file content('%s'), shoud be 'Hello, World!'", string(data))
+	}
+}

--- a/internal/storage/migration_test.go
+++ b/internal/storage/migration_test.go
@@ -27,38 +27,38 @@ func TestMigrationStorage(t *testing.T) {
 
 	migrationStorage := NewMigrationStorage(front, back)
 
-	err = back.Put("foo.txt", bytes.NewBufferString("Hello, World!"))
+	err = back.Put("test.txt", bytes.NewBufferString("Hello World!"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = front.Stat("foo.txt")
+	_, err = front.Stat("test.txt")
 	if err != ErrNotFound {
 		t.Fatal("Expected error, but got nil")
 	}
 
-	_, _, err = front.Get("foo.txt")
+	_, _, err = front.Get("test.txt")
 	if err != ErrNotFound {
 		t.Fatal("Expected error, but got nil")
 	}
 
-	fi, err := migrationStorage.Stat("foo.txt")
+	fi, err := migrationStorage.Stat("test.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if fi.Size() != 13 {
-		t.Fatalf("invalid file size(%d), shoud be 13", fi.Size())
+	if fi.Size() != 12 {
+		t.Fatalf("invalid file size(%d), shoud be 12", fi.Size())
 	}
 
-	f, fi, err := migrationStorage.Get("foo.txt")
+	f, fi, err := migrationStorage.Get("test.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer f.Close()
 
-	if fi.Size() != 13 {
-		t.Fatalf("invalid file size(%d), shoud be 13", fi.Size())
+	if fi.Size() != 12 {
+		t.Fatalf("invalid file size(%d), shoud be 12", fi.Size())
 	}
 
 	data, err := io.ReadAll(f)
@@ -66,27 +66,27 @@ func TestMigrationStorage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if string(data) != "Hello, World!" {
-		t.Fatalf("invalid file content('%s'), shoud be 'Hello, World!'", string(data))
+	if string(data) != "Hello World!" {
+		t.Fatalf("invalid file content('%s'), shoud be 'Hello World!'", string(data))
 	}
 
-	fi, err = front.Stat("foo.txt")
+	fi, err = front.Stat("test.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if fi.Size() != 13 {
-		t.Fatalf("invalid file size(%d), shoud be 13", fi.Size())
+	if fi.Size() != 12 {
+		t.Fatalf("invalid file size(%d), shoud be 12", fi.Size())
 	}
 
-	f, fi, err = front.Get("foo.txt")
+	f, fi, err = front.Get("test.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer f.Close()
 
-	if fi.Size() != 13 {
-		t.Fatalf("invalid file size(%d), shoud be 13", fi.Size())
+	if fi.Size() != 12 {
+		t.Fatalf("invalid file size(%d), shoud be 12", fi.Size())
 	}
 
 	data, err = io.ReadAll(f)
@@ -94,7 +94,7 @@ func TestMigrationStorage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if string(data) != "Hello, World!" {
-		t.Fatalf("invalid file content('%s'), shoud be 'Hello, World!'", string(data))
+	if string(data) != "Hello World!" {
+		t.Fatalf("invalid file content('%s'), shoud be 'Hello World!'", string(data))
 	}
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -20,10 +20,10 @@ type StorageOptions struct {
 
 type Storage interface {
 	Stat(key string) (stat Stat, err error)
-	List(prefix string) (keys []string, err error)
 	Get(key string) (content io.ReadCloser, stat Stat, err error)
+	List(prefix string) (keys []string, err error)
 	Put(key string, r io.Reader) error
-	Delete(keys ...string) error
+	Delete(key string) error
 	DeleteAll(prefix string) (deletedKeys []string, err error)
 }
 

--- a/internal/storage/storage_fs_test.go
+++ b/internal/storage/storage_fs_test.go
@@ -18,33 +18,33 @@ func TestFSStorage(t *testing.T) {
 	}
 	defer os.RemoveAll(root)
 
-	err = fs.Put("foo.txt", bytes.NewBufferString("Hello, World!"))
+	err = fs.Put("test.txt", bytes.NewBufferString("Hello World!"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = fs.Put("foo/bar.txt", bytes.NewBufferString("Hello, World!"))
+	err = fs.Put("hello/world.txt", bytes.NewBufferString("Hello World!"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	fi, err := fs.Stat("foo.txt")
+	fi, err := fs.Stat("test.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if fi.Size() != 13 {
-		t.Fatalf("invalid file size(%d), shoud be 13", fi.Size())
+	if fi.Size() != 12 {
+		t.Fatalf("invalid file size(%d), shoud be 12", fi.Size())
 	}
 
-	f, fi, err := fs.Get("foo.txt")
+	f, fi, err := fs.Get("test.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer f.Close()
 
-	if fi.Size() != 13 {
-		t.Fatalf("invalid file size(%d), shoud be 13", fi.Size())
+	if fi.Size() != 12 {
+		t.Fatalf("invalid file size(%d), shoud be 12", fi.Size())
 	}
 
 	data, err := io.ReadAll(f)
@@ -52,8 +52,8 @@ func TestFSStorage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if string(data) != "Hello, World!" {
-		t.Fatalf("invalid file content('%s'), shoud be 'Hello, World!'", string(data))
+	if string(data) != "Hello World!" {
+		t.Fatalf("invalid file content('%s'), shoud be 'Hello World!'", string(data))
 	}
 
 	keys, err := fs.List("")
@@ -65,7 +65,7 @@ func TestFSStorage(t *testing.T) {
 		t.Fatalf("invalid keys count(%d), shoud be 2", len(keys))
 	}
 
-	keys, err = fs.List("foo/")
+	keys, err = fs.List("hello/")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,26 +74,26 @@ func TestFSStorage(t *testing.T) {
 		t.Fatalf("invalid keys count(%d), shoud be 1", len(keys))
 	}
 
-	if keys[0] != "foo/bar.txt" {
-		t.Fatalf("invalid key('%s'), shoud be 'foo/bar.txt'", keys[0])
+	if keys[0] != "hello/world.txt" {
+		t.Fatalf("invalid key('%s'), shoud be 'hello/world.txt'", keys[0])
 	}
 
-	err = fs.Delete("foo.txt")
+	err = fs.Delete("test.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = fs.Stat("foo.txt")
+	_, err = fs.Stat("test.txt")
 	if err != ErrNotFound {
 		t.Fatalf("File should be not existent")
 	}
 
-	_, _, err = fs.Get("foo.txt")
+	_, _, err = fs.Get("test.txt")
 	if err != ErrNotFound {
 		t.Fatalf("File should be not existent")
 	}
 
-	deletedKeys, err := fs.DeleteAll("foo/")
+	deletedKeys, err := fs.DeleteAll("hello/")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,8 +102,8 @@ func TestFSStorage(t *testing.T) {
 		t.Fatalf("invalid deleted keys count(%d), shoud be 1", len(deletedKeys))
 	}
 
-	if deletedKeys[0] != "foo/bar.txt" {
-		t.Fatalf("invalid deleted key('%s'), shoud be 'foo/bar.txt'", deletedKeys[0])
+	if deletedKeys[0] != "hello/world.txt" {
+		t.Fatalf("invalid deleted key('%s'), shoud be 'hello/world.txt'", deletedKeys[0])
 	}
 
 	keys, err = fs.List("")

--- a/server/config.go
+++ b/server/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	BuildConcurrency    uint16                 `json:"buildConcurrency"`
 	BuildWaitTime       uint16                 `json:"buildWaitTime"`
 	Storage             storage.StorageOptions `json:"storage"`
+	MigrationStorage    storage.StorageOptions `json:"migrationStorage"`
 	CacheRawFile        bool                   `json:"cacheRawFile"`
 	LogDir              string                 `json:"logDir"`
 	LogLevel            string                 `json:"logLevel"`
@@ -46,7 +47,7 @@ type Config struct {
 	MinifyRaw           json.RawMessage        `json:"minify"`
 	SourceMapRaw        json.RawMessage        `json:"sourceMap"`
 	CompressRaw         json.RawMessage        `json:"compress"`
-	LegacyServer        string                 `json:"legacyServer"` // normally you don't need to set this
+	LegacyServer        string                 `json:"legacyServer"`
 	Minify              bool                   `json:"-"`
 	SourceMap           bool                   `json:"-"`
 	Compress            bool                   `json:"-"`

--- a/server/config.go
+++ b/server/config.go
@@ -34,7 +34,6 @@ type Config struct {
 	BuildWaitTime       uint16                 `json:"buildWaitTime"`
 	Storage             storage.StorageOptions `json:"storage"`
 	MigrationStorage    storage.StorageOptions `json:"migrationStorage"`
-	CacheRawFile        bool                   `json:"cacheRawFile"`
 	LogDir              string                 `json:"logDir"`
 	LogLevel            string                 `json:"logLevel"`
 	AccessLog           bool                   `json:"accessLog"`

--- a/server/router.go
+++ b/server/router.go
@@ -61,7 +61,7 @@ const (
 	ctTypeScript     = "application/typescript; charset=utf-8"
 )
 
-func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) rex.Handle {
+func esmRouter(db Database, esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 	var (
 		startTime  = time.Now()
 		globalETag = fmt.Sprintf(`W/"%s"`, VERSION)
@@ -109,12 +109,12 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 				h.Write(options.ImportMap)
 				h.Write([]byte(options.JsxImportSource))
 				h.Write([]byte(options.SourceMap))
-				h.Write([]byte(fmt.Sprintf("%v", options.Minify)))
+				fmt.Fprintf(h, "%v", options.Minify)
 				hash := hex.EncodeToString(h.Sum(nil))
 
 				// if previous build exists, return it directly
 				savePath := normalizeSavePath(ctx.R.Header.Get("X-Zone-Id"), fmt.Sprintf("modules/transform/%s.mjs", hash))
-				if file, _, err := buildStorage.Get(savePath); err == nil {
+				if file, _, err := esmStorage.Get(savePath); err == nil {
 					data, err := io.ReadAll(file)
 					file.Close()
 					if err != nil {
@@ -123,7 +123,7 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 					output := TransformOutput{
 						Code: string(data),
 					}
-					file, _, err = buildStorage.Get(savePath + ".map")
+					file, _, err = esmStorage.Get(savePath + ".map")
 					if err == nil {
 						data, err = io.ReadAll(file)
 						file.Close()
@@ -151,9 +151,9 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 				}
 				if len(output.Map) > 0 {
 					output.Code = fmt.Sprintf("%s//# sourceMappingURL=+%s", output.Code, path.Base(savePath)+".map")
-					go buildStorage.Put(savePath+".map", strings.NewReader(output.Map))
+					go esmStorage.Put(savePath+".map", strings.NewReader(output.Map))
 				}
-				go buildStorage.Put(savePath, strings.NewReader(output.Code))
+				go esmStorage.Put(savePath, strings.NewReader(output.Code))
 				ctx.SetHeader("Cache-Control", ccMustRevalidate)
 				return output
 
@@ -409,7 +409,7 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 				return rex.Status(404, "Not Found")
 			}
 			savePath := normalizeSavePath(ctx.R.Header.Get("X-Zone-Id"), fmt.Sprintf("modules/transform/%s.%s", hash, ext))
-			f, fi, err := buildStorage.Get(savePath)
+			f, fi, err := esmStorage.Get(savePath)
 			if err != nil {
 				return rex.Status(500, err.Error())
 			}
@@ -561,7 +561,7 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 				h.Write([]byte(target))
 				h.Write([]byte(v))
 				savePath := normalizeSavePath(zoneIdHeader, path.Join("modules/x", hex.EncodeToString(h.Sum(nil))+".css"))
-				r, fi, err := buildStorage.Get(savePath)
+				r, fi, err := esmStorage.Get(savePath)
 				if err != nil && err != storage.ErrNotFound {
 					return rex.Status(500, err.Error())
 				}
@@ -685,7 +685,7 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 					return rex.Status(500, ret.Errors[0].Text)
 				}
 				minifiedCSS := ret.OutputFiles[0].Contents
-				go buildStorage.Put(savePath, bytes.NewReader(minifiedCSS))
+				go esmStorage.Put(savePath, bytes.NewReader(minifiedCSS))
 				ctx.SetHeader("Cache-Control", ccImmutable)
 				ctx.SetHeader("Content-Type", ctCSS)
 				return minifiedCSS
@@ -705,7 +705,7 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 				h.Write([]byte(target))
 				h.Write([]byte(v))
 				savePath := normalizeSavePath(zoneIdHeader, path.Join("modules/x", hex.EncodeToString(h.Sum(nil))+".mjs"))
-				content, fi, err := buildStorage.Get(savePath)
+				content, fi, err := esmStorage.Get(savePath)
 				if err != nil && err != storage.ErrNotFound {
 					return rex.Status(500, err.Error())
 				}
@@ -797,7 +797,7 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 					}
 					body = bytes.NewReader([]byte(out.Code))
 					fi = nil
-					go buildStorage.Put(savePath, strings.NewReader(out.Code))
+					go esmStorage.Put(savePath, strings.NewReader(out.Code))
 				}
 				if extname == ".css" && query.Has("module") {
 					css, err := io.ReadAll(body)
@@ -1110,7 +1110,7 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 				var cacheHit bool
 				if config.CacheRawFile {
 					cachePath = path.Join("raw", esm.Name(), esm.SubPath)
-					content, stat, err = buildStorage.Get(cachePath)
+					content, stat, err = esmStorage.Get(cachePath)
 					if err != nil && err != storage.ErrNotFound {
 						return rex.Status(500, "storage error")
 					}
@@ -1164,7 +1164,7 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 								return
 							}
 							defer f.Close()
-							buildStorage.Put(cachePath, f)
+							esmStorage.Put(cachePath, f)
 						}()
 					}
 				}
@@ -1211,7 +1211,7 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 					savePath = path.Join("modules", pathname)
 				}
 				savePath = normalizeSavePath(npmrc.zoneId, savePath)
-				f, stat, err := buildStorage.Get(savePath)
+				f, stat, err := esmStorage.Get(savePath)
 				if err != nil {
 					if err != storage.ErrNotFound {
 						return rex.Status(500, err.Error())
@@ -1259,7 +1259,7 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 							xxh := xxhash.New()
 							xxh.Write([]byte(strings.Join(exports, ",")))
 							savePath = strings.TrimSuffix(savePath, ".mjs") + "_" + base64.RawURLEncoding.EncodeToString(xxh.Sum(nil)) + ".mjs"
-							f2, stat, err := buildStorage.Get(savePath)
+							f2, stat, err := esmStorage.Get(savePath)
 							if err == nil {
 								ctx.SetHeader("Content-Length", fmt.Sprintf("%d", stat.Size()))
 								return f2 // auto closed
@@ -1283,7 +1283,7 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 							if err != nil {
 								return rex.Status(500, err.Error())
 							}
-							go buildStorage.Put(savePath, bytes.NewReader(ret))
+							go esmStorage.Put(savePath, bytes.NewReader(ret))
 							// note: the source map is dropped
 							return ret
 						}
@@ -1444,7 +1444,7 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 					esm.Name(),
 					args,
 				), esm.SubPath))
-				content, stat, err = buildStorage.Get(savePath)
+				content, stat, err = esmStorage.Get(savePath)
 				return
 			}
 			content, _, err := readDts()
@@ -1456,7 +1456,7 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 					npmrc:       npmrc,
 					logger:      logger,
 					db:          db,
-					storage:     buildStorage,
+					storage:     esmStorage,
 					esmPath:     esm,
 					args:        buildArgs,
 					externalAll: externalAll,
@@ -1564,7 +1564,7 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 			npmrc:       npmrc,
 			logger:      logger,
 			db:          db,
-			storage:     buildStorage,
+			storage:     esmStorage,
 			esmPath:     esm,
 			args:        buildArgs,
 			bundleMode:  bundleMode,
@@ -1652,7 +1652,7 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 				path, _ := utils.SplitByLastByte(savePath, '.')
 				savePath = path + ".css"
 			}
-			f, fi, err := buildStorage.Get(savePath)
+			f, fi, err := esmStorage.Get(savePath)
 			if err != nil {
 				if err == storage.ErrNotFound {
 					// seem the build file is non-exist in the storage
@@ -1690,7 +1690,7 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 					xxh := xxhash.New()
 					xxh.Write([]byte(strings.Join(exports, ",")))
 					savePath = strings.TrimSuffix(savePath, ".mjs") + "_" + base64.RawURLEncoding.EncodeToString(xxh.Sum(nil)) + ".mjs"
-					f2, stat, err := buildStorage.Get(savePath)
+					f2, stat, err := esmStorage.Get(savePath)
 					if err == nil {
 						ctx.SetHeader("Content-Length", fmt.Sprintf("%d", stat.Size()))
 						return f2 // auto closed
@@ -1706,7 +1706,7 @@ func esmRouter(db Database, buildStorage storage.Storage, logger *log.Logger) re
 					if err != nil {
 						return rex.Status(500, err.Error())
 					}
-					go buildStorage.Put(savePath, bytes.NewReader(ret))
+					go esmStorage.Put(savePath, bytes.NewReader(ret))
 					// note: the source map is dropped
 					return ret
 				}

--- a/server/server.go
+++ b/server/server.go
@@ -64,11 +64,19 @@ func Serve() {
 	}
 
 	// initialize storage
-	buildStorage, err := storage.New(&config.Storage)
+	esmStorage, err := storage.New(&config.Storage)
 	if err != nil {
 		logger.Fatalf("failed to initialize build storage(%s): %v", config.Storage.Type, err)
 	}
 	logger.Debugf("storage initialized, type: %s, endpoint: %s", config.Storage.Type, config.Storage.Endpoint)
+
+	if config.MigrationStorage.Type != "" {
+		migrationStorage, err := storage.New(&config.MigrationStorage)
+		if err != nil {
+			logger.Fatalf("failed to initialize migration storage(%s): %v", config.MigrationStorage.Type, err)
+		}
+		esmStorage = storage.NewMigrationStorage(esmStorage, migrationStorage)
+	}
 
 	// pre-compile uno generator in background
 	go generateUnoCSS(&NpmRC{NpmRegistry: NpmRegistry{Registry: "https://registry.npmjs.org/"}}, "", "")
@@ -82,8 +90,8 @@ func Serve() {
 		rex.Optional(rex.AccessLogger(accessLogger), config.AccessLog),
 		rex.Optional(rex.Compress(), config.Compress),
 		rex.Optional(customLandingPage(&config.CustomLandingPage), config.CustomLandingPage.Origin != ""),
-		rex.Optional(esmLegacyRouter(buildStorage), config.LegacyServer != ""),
-		esmRouter(db, buildStorage, logger),
+		rex.Optional(esmLegacyRouter(esmStorage), config.LegacyServer != ""),
+		esmRouter(db, esmStorage, logger),
 	)
 
 	// start server

--- a/server/server.go
+++ b/server/server.go
@@ -68,8 +68,6 @@ func Serve() {
 	if err != nil {
 		logger.Fatalf("failed to initialize build storage(%s): %v", config.Storage.Type, err)
 	}
-	logger.Debugf("storage initialized, type: %s, endpoint: %s", config.Storage.Type, config.Storage.Endpoint)
-
 	if config.MigrationStorage.Type != "" {
 		migrationStorage, err := storage.New(&config.MigrationStorage)
 		if err != nil {
@@ -77,6 +75,7 @@ func Serve() {
 		}
 		esmStorage = storage.NewMigrationStorage(esmStorage, migrationStorage)
 	}
+	logger.Debugf("storage initialized, type: %s, endpoint: %s", config.Storage.Type, config.Storage.Endpoint)
 
 	// pre-compile uno generator in background
 	go generateUnoCSS(&NpmRC{NpmRegistry: NpmRegistry{Registry: "https://registry.npmjs.org/"}}, "", "")
@@ -84,8 +83,8 @@ func Serve() {
 	// add middlewares
 	rex.Use(
 		rex.Header("Server", "esm.sh"),
-		cors(config.CorsAllowOrigins),
 		rex.Logger(logger),
+		cors(config.CorsAllowOrigins),
 		pprofRouter(),
 		rex.Optional(rex.AccessLogger(accessLogger), config.AccessLog),
 		rex.Optional(rex.Compress(), config.Compress),


### PR DESCRIPTION
when switching the current storage to a new storage, the migration storage will copy the files from the old storage to the new storage lazily, to avoid breaking deno.lock