### PR TITLE
fix: analyze splitting regardless even when `sideEffects: false`

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -147,7 +147,7 @@ func (ctx *BuildContext) Build() (meta *BuildMeta, err error) {
 	}
 
 	// analyze splitting modules
-	if !ctx.pkgJson.SideEffectsFalse && ctx.bundleMode == BundleDefault && ctx.pkgJson.Exports.Len() > 1 {
+	if ctx.bundleMode == BundleDefault && ctx.pkgJson.Exports.Len() > 1 {
 		ctx.status = "analyze"
 		err = ctx.analyzeSplitting()
 		if err != nil {


### PR DESCRIPTION
Currently we don't analyze splitting when `sideEffects: false`. This can result in duplication of symbols in shared files of entry-points. Even if there are no side effects, this duplication can cause issues with singletons or identify comparisons.