### PR TITLE
Store real integrity string in the build meta structure

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -1408,7 +1408,7 @@ REBUILD:
 				err = errors.New("storage: " + err.Error())
 				return
 			}
-			meta.Integrity = sha.Sum(nil)
+			meta.Integrity = "sha384-" + base64.RawStdEncoding.EncodeToString(sha.Sum(nil))
 		}
 	}
 

--- a/server/build_meta.go
+++ b/server/build_meta.go
@@ -21,7 +21,7 @@ type BuildMeta struct {
 	CSSEntry      string
 	Dts           string
 	Imports       []string
-	Integrity     []byte
+	Integrity     string
 }
 
 func encodeBuildMeta(meta *BuildMeta) []byte {
@@ -58,7 +58,7 @@ func encodeBuildMeta(meta *BuildMeta) []byte {
 	}
 	if len(meta.Integrity) > 0 {
 		buf.Write([]byte{'~', ':'})
-		buf.Write(meta.Integrity)
+		buf.WriteString(meta.Integrity)
 		buf.WriteByte('\n')
 	}
 	return buf.Bytes()
@@ -108,7 +108,7 @@ func decodeBuildMeta(data []byte) (*BuildMeta, error) {
 			}
 			meta.Imports = append(meta.Imports, importSepcifier)
 		case ll > 2 && line[0] == '~' && line[1] == ':':
-			meta.Integrity = line[2:]
+			meta.Integrity = string(line[2:])
 		default:
 			return nil, errors.New("invalid build meta")
 		}

--- a/server/router.go
+++ b/server/router.go
@@ -1731,14 +1731,14 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 				if err != nil {
 					return rex.Status(500, err.Error())
 				}
-				integrity = sha.Sum(nil)
+				integrity = "sha384-" + base64.RawStdEncoding.EncodeToString(sha.Sum(nil))
 				buildMeta.Integrity = integrity
 				err = metaDB.Put(build.Path(), encodeBuildMeta(buildMeta))
 				if err != nil {
 					return rex.Status(500, err.Error())
 				}
 			}
-			metaJson["integrity"] = "sha384-" + base64.RawStdEncoding.EncodeToString(integrity)
+			metaJson["integrity"] = integrity
 			ctx.SetHeader("Content-Type", ctJSON)
 			if isExactVersion {
 				ctx.SetHeader("Cache-Control", ccImmutable)


### PR DESCRIPTION
`esm.sh/react?meta` returns

```json
{
  "dts": "https://esm.sh/@types/react@~19.2.9/index.d.ts",
  "exports": [
    "./jsx-runtime",
    "./jsx-dev-runtime",
    "./compiler-runtime"
  ],
  "integrity": "sha384-rxPLXyb2bDLpF2fthC4/hXAujImdBePshb2LFLvj8013vVU511h4T8Mpw5uuice3",
  "name": "react",
  "version": "19.2.4"
}
```