### PR TITLE
Fix: Scoped fork packages incorrectly resolve bare imports to upstream package

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -549,7 +549,20 @@ func (ctx *BuildContext) buildModule(analyzeMode bool) (meta *BuildMeta, include
 
 					// externalize top-level module
 					// e.g. "react/jsx-runtime" imports "react"
-					if ctx.esmPath.SubPath != "" && specifier == ctx.esmPath.PkgName && ctx.bundleMode != BundleDeps {
+					// Also handles scoped fork self-reference: "@scope/three" importing "three"
+					isSelfRef := specifier == ctx.esmPath.PkgName
+					if !isSelfRef && strings.HasPrefix(ctx.esmPath.PkgName, "@") {
+						_, baseName := utils.SplitByFirstByte(ctx.esmPath.PkgName[1:], '/')
+						specPkgName := toPackageName(specifier)
+						if specPkgName == baseName {
+							_, inDeps := pkgJson.Dependencies[specPkgName]
+							_, inPeerDeps := pkgJson.PeerDependencies[specPkgName]
+							if !inDeps && !inPeerDeps {
+								isSelfRef = true
+							}
+						}
+					}
+					if ctx.esmPath.SubPath != "" && isSelfRef && ctx.bundleMode != BundleDeps {
 						externalPath, sideEffects, err := ctx.resolveExternalModule(ctx.esmPath.PkgName, args.Kind, withTypeJSON, analyzeMode)
 						if err != nil {
 							return esbuild.OnResolveResult{}, err

--- a/server/build_resolver.go
+++ b/server/build_resolver.go
@@ -756,7 +756,22 @@ func (ctx *BuildContext) resolveExternalModule(specifier string, kind esbuild.Re
 	}
 
 	// if it's `main` entry of current package
-	if pkgJson := ctx.pkgJson; specifier == pkgJson.Name || specifier == pkgJson.PkgName {
+	// Also handles scoped fork self-reference: e.g. `@scope/three` source importing `three`
+	// when `three` is not declared as a dependency — treat as self-reference.
+	pkgJson := ctx.pkgJson
+	isSelfRef := specifier == pkgJson.Name || specifier == pkgJson.PkgName
+	if !isSelfRef && strings.HasPrefix(pkgJson.Name, "@") {
+		_, baseName := utils.SplitByFirstByte(pkgJson.Name[1:], '/')
+		specPkgName := toPackageName(specifier)
+		if specPkgName == baseName {
+			_, inDeps := pkgJson.Dependencies[specPkgName]
+			_, inPeerDeps := pkgJson.PeerDependencies[specPkgName]
+			if !inDeps && !inPeerDeps {
+				isSelfRef = true
+			}
+		}
+	}
+	if isSelfRef {
 		esmPath := EsmPath{
 			GhPrefix:   ctx.esmPath.GhPrefix,
 			PrPrefix:   ctx.esmPath.PrPrefix,
@@ -777,10 +792,22 @@ func (ctx *BuildContext) resolveExternalModule(specifier string, kind esbuild.Re
 	}
 
 	// if it's a sub-module of current package
+	// Also handles scoped fork sub-paths: e.g. `@scope/three` source importing `three/tsl`
 	{
 		subPath, ok := strings.CutPrefix(specifier, ctx.pkgJson.Name+"/")
 		if !ok {
 			subPath, ok = strings.CutPrefix(specifier, ctx.pkgJson.PkgName+"/")
+		}
+		if !ok && strings.HasPrefix(ctx.pkgJson.Name, "@") {
+			_, baseName := utils.SplitByFirstByte(ctx.pkgJson.Name[1:], '/')
+			specPkgName := toPackageName(specifier)
+			if specPkgName == baseName {
+				_, inDeps := ctx.pkgJson.Dependencies[specPkgName]
+				_, inPeerDeps := ctx.pkgJson.PeerDependencies[specPkgName]
+				if !inDeps && !inPeerDeps {
+					subPath, ok = strings.CutPrefix(specifier, baseName+"/")
+				}
+			}
 		}
 		if ok {
 			subModule := EsmPath{

--- a/test/scoped-fork/test.ts
+++ b/test/scoped-fork/test.ts
@@ -1,0 +1,36 @@
+import { assertStringIncludes } from "jsr:@std/assert";
+
+// Test: scoped fork packages should resolve bare imports as self-references.
+// When @needle-tools/three (a scoped fork of three.js) internally imports "three",
+// it should resolve to itself, not to upstream "three@latest".
+
+Deno.test("scoped fork: bare import resolves to self-reference", async () => {
+  // Fetch a sub-module that explicitly imports from bare "three" internally.
+  // Gyroscope.js starts with: import { Object3D, Quaternion } from 'three';
+  // Without the fix, esm.sh would resolve this to the upstream "three" package,
+  // producing an import like `from"/three@..."` instead of `from"/@needle-tools/three@..."`.
+  const res = await fetch(
+    "http://localhost:8080/@needle-tools/three@0.169.19/examples/jsm/misc/Gyroscope.js?target=es2022",
+  );
+  const text = await res.text();
+  // The resolved import must reference @needle-tools/three (self-ref), NOT bare "/three@..."
+  assertStringIncludes(text, "/@needle-tools/three@");
+});
+
+Deno.test("scoped fork: bare import does NOT resolve to upstream package", async () => {
+  // Negative test: if the fix regresses, esm.sh would resolve `three` to the upstream
+  // package, producing a path like `from"/three@0.xxx/..."` in the output.
+  const res = await fetch(
+    "http://localhost:8080/@needle-tools/three@0.169.19/examples/jsm/misc/Gyroscope.js?target=es2022",
+  );
+  const text = await res.text();
+  // Must NOT contain a reference to the upstream /three@ package
+  const badImports = text.split("\n").filter(
+    (l) => l.includes('"/three@') && !l.includes("@needle-tools/three"),
+  );
+  if (badImports.length > 0) {
+    throw new Error(
+      `Bare 'three' was resolved to upstream package instead of self-reference:\n${badImports.join("\n")}`,
+    );
+  }
+});


### PR DESCRIPTION
Fixes
- #1247.

When a scoped fork package (e.g. `@needle-tools/three`, a fork of `three`) has
source files that import from the bare original name (e.g. `import { x } from 'three'`),
esm.sh resolves that to the upstream `three` package instead of the package itself.

**To reproduce:**
This is enough to reproduce the issue:
```sh
curl 'https://esm.sh/@needle-tools/three@0.169.19/examples/jsm/misc/Gyroscope.js?target=es2022'
```

Current output (broken):
```ts
import "/three?target=es2022";   // ← wrong: resolves to upstream three, and to a completely different version at that, not the scoped fork
export * from "/@needle-tools/three@0.169.19/es2022/examples/jsm/misc/Gyroscope.mjs";
```

Expected output (with this PR):
```ts
import "/@needle-tools/three@0.169.19/es2022/three.mjs";
export * from "/@needle-tools/three@0.169.19/es2022/examples/jsm/misc/Gyroscope.mjs";
```

**The fix:** When resolving a bare specifier inside a scoped package, if the
specifier matches the base name of the current package (e.g. `three` inside
`@scope/three`) *and* is not listed in `dependencies` or `peerDependencies`,
treat it as a self-reference. Applied in `build_resolver.go` (main entry +
sub-module paths) and `build.go` (top-level module externalize check).

Includes a regression test using `@needle-tools/three@0.169.19/examples/jsm/misc/Gyroscope.js`,
which explicitly imports from `'three'` and is publicly available on npm.

