### PR TITLE
feat: support `keepNames` and `ignoreAnnotations` options of `esm.sh` field in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,11 +390,11 @@ esm.sh supports configuring the build options by adding the `esm.sh` field to yo
 {
   "name": "your-package",
   "esm.sh": {
-    // disable the default bundling behavior
-    "bundle": false,
-    // prevent class/function names erasing
+    // set to false to disable the default bundling behavior
+    "bundle": true,
+    // set to true to prevent class/function names erasing
     "keepNames": false,
-    // some libs maybe use wrong side-effect annotations
+    // set to true to ignore side-effect annotations
     "ignoreAnnotations": false
   }
 }

--- a/README.md
+++ b/README.md
@@ -382,6 +382,24 @@ import unescape from "https://esm.sh/lodash/unescape?no-dts";
 This will prevent the `X-TypeScript-Types` header from being included in the network request, and you can manually
 specify the types for the imported module.
 
+## esm.sh Configuration
+
+esm.sh supports configuring the build options by adding the `esm.sh` field to your `package.json`:
+
+```jsonc
+{
+  "name": "your-package",
+  "esm.sh": {
+    // disable the default bundling behavior
+    "bundle": false,
+    // prevent class/function names erasing
+    "keepNames": false,
+    // some libs maybe use wrong side-effect annotations
+    "ignoreAnnotations": false
+  }
+}
+```
+
 ## Supporting Node.js/Bun
 
 esm.sh is not supported by Node.js/Bun currently.

--- a/internal/npm/package_json.go
+++ b/internal/npm/package_json.go
@@ -56,7 +56,6 @@ type PackageJSON struct {
 	Main             string
 	Module           string
 	Types            string
-	Typings          string
 	SideEffectsFalse bool
 	SideEffects      set.ReadOnlySet[string]
 	Browser          map[string]string
@@ -173,7 +172,6 @@ func (a *PackageJSONRaw) ToNpmPackage() *PackageJSON {
 		Main:             a.Main.String(),
 		Module:           a.Module.String(),
 		Types:            a.Types.String(),
-		Typings:          a.Typings.String(),
 		Browser:          browser,
 		SideEffectsFalse: sideEffectsFalse,
 		SideEffects:      *sideEffects.ReadOnly(),
@@ -185,6 +183,10 @@ func (a *PackageJSONRaw) ToNpmPackage() *PackageJSON {
 		Esmsh:            asMap(a.Esmsh),
 		Deprecated:       depreacted,
 		Dist:             dist,
+	}
+
+	if p.Types == "" {
+		p.Types = a.Typings.String()
 	}
 
 	// normalize package module field

--- a/server/build.go
+++ b/server/build.go
@@ -170,7 +170,7 @@ func (ctx *BuildContext) Build(buildCtx context.Context) (meta *BuildMeta, err e
 	}
 
 	// analyze splitting modules if bundling
-	if ctx.pkgJson.Exports.Len() > 1 && !ctx.isNoBundle() {
+	if ctx.pkgJson.Exports.Len() > 1 && ctx.shouldBundle() {
 		ctx.status = "analyze"
 		err = ctx.analyzeSplitting()
 		if err != nil {
@@ -400,7 +400,7 @@ func (ctx *BuildContext) buildModule(analyzeMode bool) (meta *BuildMeta, include
 
 	browserExclude := map[string]*set.Set[string]{}
 	implicitExternal := set.New[string]()
-	noBundle := ctx.isNoBundle()
+	noBundle := !ctx.shouldBundle()
 	esmifyPlugin := esbuild.Plugin{
 		Name: "esmify",
 		Setup: func(build esbuild.PluginBuild) {
@@ -1083,6 +1083,20 @@ func (ctx *BuildContext) buildModule(analyzeMode bool) (meta *BuildMeta, include
 		// disable minification for development build
 		minify = false
 	}
+	keepNames := ctx.args.KeepNames
+	ignoreAnnotations := ctx.args.IgnoreAnnotations
+	if esmsh := ctx.pkgJson.Esmsh; esmsh != nil {
+		if v, ok := esmsh["keepNames"]; ok {
+			if b, ok := v.(bool); ok {
+				keepNames = b
+			}
+		}
+		if v, ok := esmsh["ignoreAnnotations"]; ok {
+			if b, ok := v.(bool); ok {
+				ignoreAnnotations = b
+			}
+		}
+	}
 	options := esbuild.BuildOptions{
 		AbsWorkingDir:     ctx.wd,
 		PreserveSymlinks:  true,
@@ -1097,8 +1111,8 @@ func (ctx *BuildContext) buildModule(analyzeMode bool) (meta *BuildMeta, include
 		MinifyWhitespace:  minify,
 		MinifyIdentifiers: minify,
 		MinifySyntax:      minify,
-		KeepNames:         ctx.args.KeepNames,         // prevent class/function names erasing
-		IgnoreAnnotations: ctx.args.IgnoreAnnotations, // some libs maybe use wrong side-effect annotations
+		KeepNames:         keepNames,
+		IgnoreAnnotations: ignoreAnnotations,
 		Conditions:        conditions,
 		Loader:            loaders,
 		Plugins:           []esbuild.Plugin{esmifyPlugin},
@@ -1598,14 +1612,16 @@ func (ctx *BuildContext) install() (err error) {
 	return
 }
 
-func (ctx *BuildContext) isNoBundle() bool {
-	noBundle := ctx.bundleMode == BundleFalse || ctx.pkgJson.SideEffects.Len() > 0
+func (ctx *BuildContext) shouldBundle() bool {
+	if ctx.bundleMode == BundleFalse || ctx.pkgJson.SideEffects.Len() > 0 {
+		return false
+	}
 	if ctx.pkgJson.Esmsh != nil {
 		if v, ok := ctx.pkgJson.Esmsh["bundle"]; ok {
 			if b, ok := v.(bool); ok && !b {
-				noBundle = true
+				return false
 			}
 		}
 	}
-	return noBundle
+	return true
 }

--- a/server/build_resolver.go
+++ b/server/build_resolver.go
@@ -227,8 +227,6 @@ func (ctx *BuildContext) resolveEntry(esm EsmPath) (entry BuildEntry) {
 			if entry.types == "" {
 				if p.Types != "" && ctx.existsPkgFile(subPath, p.Types) {
 					entry.types = "./" + path.Join(subPath, p.Types)
-				} else if p.Typings != "" && ctx.existsPkgFile(subPath, p.Typings) {
-					entry.types = "./" + path.Join(subPath, p.Typings)
 				}
 			}
 		}
@@ -307,8 +305,6 @@ func (ctx *BuildContext) resolveEntry(esm EsmPath) (entry BuildEntry) {
 		}
 		if pkgJson.Types != "" {
 			entry.types = normalizeEntryPath(pkgJson.Types)
-		} else if pkgJson.Typings != "" {
-			entry.types = normalizeEntryPath(pkgJson.Typings)
 		}
 		if len(pkgJson.Browser) > 0 && ctx.isBrowserTarget() {
 			if path, ok := pkgJson.Browser["."]; ok && ctx.existsPkgFile(path) {
@@ -1034,7 +1030,7 @@ func (ctx *BuildContext) resolveDTS(entry BuildEntry) (string, error) {
 		), nil
 	}
 
-	if ctx.esmPath.SubPath != "" && (ctx.pkgJson.Types != "" || ctx.pkgJson.Typings != "") {
+	if ctx.esmPath.SubPath != "" && ctx.pkgJson.Types != "" {
 		return "", nil
 	}
 

--- a/server/router.go
+++ b/server/router.go
@@ -557,8 +557,6 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 			types := "index.d.ts"
 			if info.Types != "" {
 				types = info.Types
-			} else if info.Typings != "" {
-				types = info.Typings
 			} else if info.Main != "" && endsWith(info.Main, ".d.ts", ".d.mts", ".d.cts") {
 				types = info.Main
 			}


### PR DESCRIPTION
esm.sh supports configuring the build options by adding the `esm.sh` field to your `package.json`:

```jsonc
{
  "name": "your-package",
  "esm.sh": {
    // disable the default bundling behavior
    "bundle": false,
    // prevent class/function names erasing
    "keepNames": false,
    // some libs maybe use wrong side-effect annotations
    "ignoreAnnotations": false
  }
}
```

close #1340 