### PR TITLE
Expose and fix bug with css entry slicing

### DIFF
--- a/server/router.go
+++ b/server/router.go
@@ -1304,7 +1304,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 		}
 
 		if buildMeta.CSSEntry != "" {
-			url := strings.Join([]string{origin, esmPath.PackageId(), buildMeta.CSSEntry[2:]}, "/")
+			url := getCSSEntryRedirectURL(origin, esmPath, buildMeta.CSSEntry)			
 			return redirect(ctx, url, isExactVersion)
 		}
 
@@ -1616,4 +1616,8 @@ func errorJS(ctx *rex.Context, message string) any {
 	ctx.SetHeader("Content-Type", ctJavaScript)
 	ctx.SetHeader("Cache-Control", ccImmutable)
 	return buf.Bytes()
+}
+
+func getCSSEntryRedirectURL(origin string, esmPath EsmPath, cssEntry string) string {
+	return origin + "/" + esmPath.PackageId() + utils.NormalizePathname(cssEntry)
 }

--- a/server/router_test.go
+++ b/server/router_test.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"testing"
+)
+
+func TestCSSEntryRedirectURL(t *testing.T) {
+	origin := "https://esm.sh"
+	esmPath := EsmPath{
+		PkgName:    "@material/web",
+		PkgVersion: "2.4.2-nightly.95dd57c.0",
+	}
+
+	tests := []struct {
+		cssEntry string
+		expected string
+	}{
+		{
+			cssEntry: "./labs/gb/components/ripple/ripple.css",
+			expected: "https://esm.sh/@material/web@2.4.2-nightly.95dd57c.0/labs/gb/components/ripple/ripple.css",
+		},
+		{
+			cssEntry: "labs/gb/components/ripple/ripple.css",
+			expected: "https://esm.sh/@material/web@2.4.2-nightly.95dd57c.0/labs/gb/components/ripple/ripple.css",
+		},
+	}
+
+	for _, test := range tests {
+		// Calling the actual helper function from router.go
+		url := getCSSEntryRedirectURL(origin, esmPath, test.cssEntry)
+		if url != test.expected {
+			t.Errorf("For CSSEntry %q, expected %q, but got %q", test.cssEntry, test.expected, url)
+		}
+	}
+}


### PR DESCRIPTION
Aspires to fix bad css redirect observed when using esm.run with @material/web:

```html
<head>
  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
  <script type="importmap">
    {
      "imports": {
        "@material/web/": "https://esm.sh/@material/web@2.4.2-nightly.95dd57c.0/"
      }
    }
  </script>
  <script type="module">
    import '@material/web/labs/gb/components/button/md-button.js';
  </script>
</head>
<body>
  <form>
    <md-button color="filled">Click Me!</md-button>
  </form>
</body>
```
Reports 404 on two files:

* https://esm.sh/@material/web@2.4.2-nightly.95dd57c.0/bs/gb/components/focus/focus-ring.css
* https://esm.sh/@material/web@2.4.2-nightly.95dd57c.0/bs/gb/components/ripple/ripple.css

If we test request button from https://esm.sh/@material/web@2.4.2-nightly.95dd57c.0/labs/gb/components/button/md-button.js we can see it in turn fetches a bunch of resources:

```javascript
/* esm.sh - @material/web@2.4.2-nightly.95dd57c.0/labs/gb/components/button/md-button */
import "/@material/web@2.4.2-nightly.95dd57c.0/es2022/internal/aria/delegate.mjs";
import "/@material/web@2.4.2-nightly.95dd57c.0/es2022/internal/events/dispatch-hooks.mjs";
import "/@material/web@2.4.2-nightly.95dd57c.0/es2022/internal/events/redispatch-event.mjs";
import "/@material/web@2.4.2-nightly.95dd57c.0/es2022/labs/behaviors/element-internals.mjs";
import "/@material/web@2.4.2-nightly.95dd57c.0/es2022/labs/behaviors/form-associated.mjs";
import "/@material/web@2.4.2-nightly.95dd57c.0/es2022/labs/behaviors/form-submitter.mjs";
import "/@material/web@2.4.2-nightly.95dd57c.0/es2022/labs/gb/components/focus/focus-ring.css.mjs";
import "/@material/web@2.4.2-nightly.95dd57c.0/es2022/labs/gb/components/focus/focus-ring.mjs";
import "/@material/web@2.4.2-nightly.95dd57c.0/es2022/labs/gb/components/ripple/ripple.css.mjs";
import "/@material/web@2.4.2-nightly.95dd57c.0/es2022/labs/gb/components/ripple/ripple.mjs";
import "/@material/web@2.4.2-nightly.95dd57c.0/es2022/labs/gb/components/shared/directives.mjs";
import "/@material/web@2.4.2-nightly.95dd57c.0/es2022/labs/gb/components/shared/pseudo-classes.mjs";
import "/lit@^2.8.0%20||%20^3.0.0/decorators?target=es2022";
import "/lit@^2.8.0%20||%20^3.0.0?target=es2022";
import "/tslib@^2.4.0?target=es2022";
export * from "/@material/web@2.4.2-nightly.95dd57c.0/es2022/labs/gb/components/button/md-button.mjs";
```

If we request ripple we can see the problem: the `/labs/` segment is turned into `/bs/`

```
$ curl -i https://esm.sh/@material/web@2.4.2-nightly.95dd57c.0/es2022/labs/gb/components/ripple/
ripple.css.mjs
HTTP/2 301 
date: Tue, 21 Apr 2026 00:50:03 GMT
content-length: 0
location: https://esm.sh/@material/web@2.4.2-nightly.95dd57c.0/bs/gb/components/ripple/ripple.css
                                                               ^ bs? What happened to labs?!
access-control-allow-origin: *
cache-control: public, max-age=31536000, immutable
server: cloudflare
age: 259
cf-cache-status: HIT
cf-ray: 9ef8647629f2d81b-SJC
```

NOTE: there are further suspicious looking `[2:]` in _at least_:

* https://github.com/esm-dev/esm.sh/blob/923cdfd8e9a64cd29508a87fde64bf52e24bb604/server/build_resolver.go#L486
* https://github.com/esm-dev/esm.sh/blob/923cdfd8e9a64cd29508a87fde64bf52e24bb604/server/cjs_module_lexer.go#L85