### PR TITLE
Stop support of legacy routes

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -49,7 +49,6 @@ type Config struct {
 	MinifyRaw           json.RawMessage              `json:"minify"`
 	SourceMapRaw        json.RawMessage              `json:"sourceMap"`
 	CompressRaw         json.RawMessage              `json:"compress"`
-	LegacyServer        string                       `json:"legacyServer"`
 	Minify              bool                         `json:"-"`
 	SourceMap           bool                         `json:"-"`
 	Compress            bool                         `json:"-"`

--- a/server/legacy_router.go
+++ b/server/legacy_router.go
@@ -259,7 +259,7 @@ func legacyESM(ctx *rex.Context, fs storage.Storage, buildVersionPrefix string) 
 		} else if pathname == "/node.ns.d.ts" {
 			return rex.Status(404, "Not Found")
 		}
-		return redirect(ctx, fmt.Sprintf("%s%s", origin, pathname), true)
+		return redirect(ctx, fmt.Sprintf("%s%s%s", origin, pathname, query), true)
 	}
 
 	return rex.Next()

--- a/server/legacy_router.go
+++ b/server/legacy_router.go
@@ -254,7 +254,7 @@ func legacyESM(ctx *rex.Context, fs storage.Storage, buildVersionPrefix string) 
 	// strip leading `/stable/*` and `/v<build-version>/*`
 	if buildVersionPrefix != "" {
 		origin := getOrigin(ctx)
-		if strings.HasPrefix(pathname, "/node_") || strings.HasSuffix(pathname, ".js") {
+		if strings.HasPrefix(pathname, "/node_") && strings.HasSuffix(pathname, ".js") {
 			pathname = "/node/" + strings.TrimSuffix(strings.TrimPrefix(pathname, "/node_"), ".js") + ".mjs"
 		} else if pathname == "/node.ns.d.ts" {
 			return rex.Status(404, "Not Found")

--- a/server/legacy_router.go
+++ b/server/legacy_router.go
@@ -6,13 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"path"
 	"strconv"
 	"strings"
 
-	"github.com/esm-dev/esm.sh/internal/fetch"
 	"github.com/esm-dev/esm.sh/internal/npm"
 	"github.com/esm-dev/esm.sh/internal/storage"
 	"github.com/ije/esbuild-internal/xxhash"
@@ -201,7 +199,7 @@ func legacyESM(ctx *rex.Context, fs storage.Storage, buildVersionPrefix string) 
 							return rex.Status(500, "Failed to read data from storage")
 						}
 						data = bytes.ReplaceAll(data, []byte("https://esm.sh/v"), []byte(origin+"/v"))
-						data = bytes.ReplaceAll(data, []byte(config.LegacyServer+"/v"), []byte(origin+"/v"))
+						data = bytes.ReplaceAll(data, []byte("https://legacy.esm.sh/v"), []byte(origin+"/v"))
 						return data
 					}
 				}
@@ -253,90 +251,16 @@ func legacyESM(ctx *rex.Context, fs storage.Storage, buildVersionPrefix string) 
 		}
 	}
 
-	url, err := ctx.R.URL.Parse(config.LegacyServer + ctx.R.URL.Path + query)
-	if err != nil {
-		return rex.Status(http.StatusBadRequest, "Invalid url")
+	// strip leading `/stable/*` and `/v<build-version>/*`
+	if buildVersionPrefix != "" {
+		origin := getOrigin(ctx)
+		if strings.HasPrefix(pathname, "/node_") || strings.HasSuffix(pathname, ".js") {
+			pathname = "/node/" + strings.TrimSuffix(strings.TrimPrefix(pathname, "/node_"), ".js") + ".mjs"
+		} else if pathname == "/node.ns.d.ts" {
+			return rex.Status(404, "Not Found")
+		}
+		return redirect(ctx, fmt.Sprintf("%s%s", origin, pathname), true)
 	}
 
-	client := fetch.NewClient(ctx.UserAgent(), 60, true)
-	res, err := client.Fetch(url, nil)
-	if err != nil {
-		return rex.Status(http.StatusBadGateway, "Failed to connect the legacy esm.sh server")
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode == 301 || res.StatusCode == 302 {
-		url := res.Header.Get("Location")
-		if after, ok := strings.CutPrefix(url, "https://legacy.esm.sh"); ok {
-			url = getOrigin(ctx) + after
-		}
-		return redirect(ctx, url, res.StatusCode == 301)
-	}
-
-	if res.StatusCode != 200 {
-		data, err := io.ReadAll(res.Body)
-		if err != nil {
-			return rex.Status(500, "Failed to fetch data from the legacy esm.sh server")
-		}
-		ctx.SetHeader("Cache-Control", "public, max-age=600")
-		return rex.Status(res.StatusCode, data)
-	}
-
-	if (buildVersionPrefix != "" && isStatic) || endsWith(pathname, ".d.ts", ".d.mts") {
-		data, err := io.ReadAll(res.Body)
-		if err != nil {
-			return rex.Status(500, "Failed to fetch data from the legacy esm.sh server")
-		}
-		err = fs.Put(savePath, bytes.NewReader(data))
-		if err != nil {
-			return rex.Status(500, "Storage error: "+err.Error())
-		}
-		ctx.SetHeader("Content-Type", res.Header.Get("Content-Type"))
-		ctx.SetHeader("Cache-Control", ccImmutable)
-		// resolve hostname in typescript definition files if the origin is not "https://esm.sh"
-		if endsWith(pathname, ".d.ts", ".d.mts") {
-			origin := getOrigin(ctx)
-			if origin != "https://esm.sh" {
-				data = bytes.ReplaceAll(data, []byte("https://esm.sh/v"), []byte(origin+"/v"))
-				data = bytes.ReplaceAll(data, []byte(config.LegacyServer+"/v"), []byte(origin+"/v"))
-			}
-		}
-		return data
-	} else {
-		code, err := io.ReadAll(res.Body)
-		if err != nil {
-			return rex.Status(500, "Failed to fetch data from the legacy esm.sh server")
-		}
-		esmId := res.Header.Get("X-Esm-Id")
-		dts := res.Header.Get("X-TypeScript-Types")
-		if dts != "" {
-			u, err := url.Parse(dts)
-			if err != nil {
-				dts = ""
-			} else {
-				dts = u.Path
-			}
-		}
-		ret := LegacyBuildMeta{
-			EsmId: esmId,
-			Dts:   dts,
-			Code:  string(code),
-		}
-		err = fs.Put(savePath, bytes.NewReader(utils.MustEncodeJSON(ret)))
-		if err != nil {
-			return rex.Status(500, "Storage error: "+err.Error())
-		}
-		ctx.SetHeader("Content-Type", res.Header.Get("Content-Type"))
-		ctx.SetHeader("Cache-Control", ccImmutable)
-		if query != "" && !ctx.R.URL.Query().Has("target") {
-			appendVaryHeader(ctx.W.Header(), "User-Agent")
-		}
-		if esmId != "" {
-			ctx.SetHeader("X-ESM-Id", esmId)
-		}
-		if dts != "" {
-			ctx.SetHeader("X-TypeScript-Types", getOrigin(ctx)+dts)
-		}
-		return code
-	}
+	return rex.Next()
 }

--- a/server/server.go
+++ b/server/server.go
@@ -79,7 +79,7 @@ func Start() {
 		rex.Optional(rex.AccessLogger(accessLogger), config.AccessLog),
 		rex.Optional(rex.Compress(), config.Compress),
 		rex.Optional(customLandingPage(&config.CustomLandingPage), config.CustomLandingPage.Origin != ""),
-		rex.Optional(esmLegacyRouter(esmStorage), config.LegacyServer != ""),
+		esmLegacyRouter(esmStorage),
 		esmRouter(esmStorage, logger),
 	)
 

--- a/test/bootstrap.ts
+++ b/test/bootstrap.ts
@@ -17,7 +17,6 @@ async function startServer(onStart: () => Promise<void>) {
       {
         "port": 8080,
         "workDir": ".esmd",
-        "legacyServer": "https://legacy.esm.sh",
         ...configJson,
       },
       undefined,

--- a/test/legacy-routes/test.ts
+++ b/test/legacy-routes/test.ts
@@ -35,7 +35,7 @@ Deno.test("legacy deprecated routes", async () => {
   }
 });
 
-Deno.test("legacy routes (hit cache)", async () => {
+Deno.test("legacy routes (cache hit)", async () => {
   // fake cache
   await writeTextFile(
     ".esmd/storage/legacy/v135/react@19.0.0.meta",
@@ -104,7 +104,7 @@ Deno.test("legacy routes (hit cache)", async () => {
   }
 });
 
-Deno.test("legacy routes (miss cache)", async () => {
+Deno.test("legacy routes (cache miss)", async () => {
   {
     const res = await fetch("http://localhost:8080/stable/react@18.3.1", {
       redirect: "manual",
@@ -120,6 +120,14 @@ Deno.test("legacy routes (miss cache)", async () => {
     res.body?.cancel();
     assertEquals(res.status, 301);
     assert(res.headers.get("Location")?.startsWith("http://localhost:8080/react@18.3.1"));
+  }
+  {
+    const res = await fetch("http://localhost:8080/v135/react@18.3.1?target=2018", {
+      redirect: "manual",
+    });
+    res.body?.cancel();
+    assertEquals(res.status, 301);
+    assert(res.headers.get("Location")?.startsWith("http://localhost:8080/react@18.3.1?target=2018"));
   }
   {
     const res = await fetch("http://localhost:8080/stable/react", {

--- a/test/legacy-routes/test.ts
+++ b/test/legacy-routes/test.ts
@@ -1,6 +1,6 @@
 import { assert, assertEquals, assertStringIncludes } from "jsr:@std/assert";
 
-Deno.test("legacy routes", async () => {
+Deno.test("legacy deprecated routes", async () => {
   try {
     await import("http://localhost:8080/");
   } catch (err: any) {
@@ -28,101 +28,98 @@ Deno.test("legacy routes", async () => {
     assertEquals(typeof build, "function");
     assertEquals(typeof transform, "function");
     try {
-      esm``;
+      esm`let i: number = 0;`;
     } catch (err: any) {
       assertStringIncludes(err.message, "deprecated");
     }
   }
+});
+
+Deno.test("legacy routes (hit cache)", async () => {
+  // fake cache
+  await writeTextFile(
+    ".esmd/storage/legacy/v135/react@19.0.0.meta",
+    JSON.stringify({
+      "esmId": "stable/react@19.0.0/es2022/react.mjs",
+      "dts": "/v135/@types/react@latest/index.d.ts",
+      "code":
+        '/* esm.sh - react@19.0.0 */\nexport * from "/stable/react@19.0.0/es2022/react.mjs";\nexport { default } from "/stable/react@19.0.0/es2022/react.mjs";\n',
+    }),
+  );
+  await writeTextFile(
+    ".esmd/storage/legacy/react-dom@19.2.5.y35WJGFJWuY.meta",
+    JSON.stringify({
+      "esmId": "v135/react-dom@19.2.5/X-ZS9yZWFjdA/es2022/react-dom.mjs",
+      "dts": "/v135/@types/react-dom@~19.2/X-ZS9yZWFjdA/index.d.ts",
+      "code":
+        '/* esm.sh - react-dom@19.2.5 */\nexport * from "/v135/react-dom@19.2.5/X-ZS9yZWFjdA/es2022/react-dom.mjs";\nexport { default } from "/v135/react-dom@19.2.5/X-ZS9yZWFjdA/es2022/react-dom.mjs";\n',
+    }),
+  );
+  await writeTextFile(".esmd/storage/legacy/v135/react@19.2.5/es2022/react.js", "export const version = '19.2.5';");
+  await writeTextFile(".esmd/storage/legacy/v135/@types/react@19.2.5/index.d.ts", "export const version:string;");
+
   {
-    const res = await fetch("http://localhost:8080/react-dom@18.3.1?pin=v135", {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-      },
-    });
-    assertEquals(res.status, 200);
-    assertEquals(res.headers.get("Content-Type"), "application/javascript; charset=utf-8");
-    assertEquals(res.headers.get("X-Esm-Id"), "v135/react-dom@18.3.1/es2022/react-dom.mjs");
-    assertEquals(res.headers.get("X-TypeScript-Types"), "http://localhost:8080/v135/@types/react-dom@~18.3/index.d.ts");
-    assertStringIncludes(await res.text(), "/v135/react-dom@18.3.1/es2022/react-dom.mjs");
-  }
-  {
-    const res = await fetch("http://localhost:8080/react-dom@18.3.1?pin=v135&dev", {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-      },
-    });
-    assertEquals(res.status, 200);
-    assertEquals(res.headers.get("Content-Type"), "application/javascript; charset=utf-8");
-    assertEquals(res.headers.get("X-Esm-Id"), "v135/react-dom@18.3.1/es2022/react-dom.development.mjs");
-    assertEquals(res.headers.get("X-TypeScript-Types"), "http://localhost:8080/v135/@types/react-dom@~18.3/index.d.ts");
-    assertStringIncludes(await res.text(), "/v135/react-dom@18.3.1/es2022/react-dom.development.mjs");
-  }
-  {
-    const res = await fetch("http://localhost:8080/react-dom@18.3.1&pin=v135&dev", {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-      },
-    });
-    assertEquals(res.status, 200);
-    assertEquals(res.headers.get("Content-Type"), "application/javascript; charset=utf-8");
-    assertEquals(res.headers.get("X-Esm-Id"), "v135/react-dom@18.3.1/es2022/react-dom.development.mjs");
-    assertEquals(res.headers.get("X-TypeScript-Types"), "http://localhost:8080/v135/@types/react-dom@~18.3/index.d.ts");
-    assertStringIncludes(await res.text(), "/v135/react-dom@18.3.1/es2022/react-dom.development.mjs");
-  }
-  {
-    const res = await fetch("http://localhost:8080/react-dom@18&pin=v135&dev", {
+    const res = await fetch("http://localhost:8080/v135/react@19.0.0", {
       redirect: "manual",
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-      },
+      headers: { "User-Agent": "i'm a browser" },
     });
-    res.body?.cancel();
-    assertEquals(res.status, 302);
-    assert(res.headers.get("Location")?.startsWith("http://localhost:8080/react-dom@18."));
-    assert(res.headers.get("Location")?.endsWith("&pin=v135&dev"));
-  }
-  {
-    const res = await fetch("http://localhost:8080/react-dom@18.3.1/client?pin=v135", {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-      },
-    });
+    const text = await res.text();
     assertEquals(res.status, 200);
-    assertEquals(res.headers.get("Content-Type"), "application/javascript; charset=utf-8");
-    assertEquals(res.headers.get("X-Esm-Id"), "v135/react-dom@18.3.1/es2022/client.js");
-    assertEquals(res.headers.get("X-TypeScript-Types"), "http://localhost:8080/v135/@types/react-dom@~18.3/client~.d.ts");
-    assertStringIncludes(await res.text(), "/v135/react-dom@18.3.1/es2022/client.js");
+    assertEquals(res.headers.get("x-esm-id"), "stable/react@19.0.0/es2022/react.mjs");
+    assertEquals(res.headers.get("x-typescript-types"), "http://localhost:8080/v135/@types/react@latest/index.d.ts");
+    assertEquals(
+      text,
+      '/* esm.sh - react@19.0.0 */\nexport * from "/stable/react@19.0.0/es2022/react.mjs";\nexport { default } from "/stable/react@19.0.0/es2022/react.mjs";\n',
+    );
   }
+
+  {
+    const res = await fetch("http://localhost:8080/react-dom@19.2.5?pin=v135&target=2018&external=react", {
+      redirect: "manual",
+      headers: { "User-Agent": "i'm a browser" },
+    });
+    const text = await res.text();
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get("x-esm-id"), "v135/react-dom@19.2.5/X-ZS9yZWFjdA/es2022/react-dom.mjs");
+    assertEquals(res.headers.get("x-typescript-types"), "http://localhost:8080/v135/@types/react-dom@~19.2/X-ZS9yZWFjdA/index.d.ts");
+    assertEquals(text, '/* esm.sh - react-dom@19.2.5 */\nexport * from "/v135/react-dom@19.2.5/X-ZS9yZWFjdA/es2022/react-dom.mjs";\nexport { default } from "/v135/react-dom@19.2.5/X-ZS9yZWFjdA/es2022/react-dom.mjs";\n');
+  }
+
+  {
+    const res = await fetch("http://localhost:8080/v135/react@19.2.5/es2022/react.js", {
+      redirect: "manual",
+    });
+    const text = await res.text();
+    assertEquals(res.status, 200);
+    assertEquals(text, "export const version = '19.2.5';");
+  }
+
+  {
+    const res = await fetch("http://localhost:8080/v135/@types/react@19.2.5/index.d.ts", {
+      redirect: "manual",
+    });
+    const text = await res.text();
+    assertEquals(res.status, 200);
+    assertEquals(text, "export const version:string;");
+  }
+});
+
+Deno.test("legacy routes (miss cache)", async () => {
   {
     const res = await fetch("http://localhost:8080/stable/react@18.3.1", {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-      },
+      redirect: "manual",
     });
-    assertEquals(res.status, 200);
-    assertEquals(res.headers.get("Content-Type"), "application/javascript; charset=utf-8");
-    assertEquals(res.headers.get("X-Esm-Id"), "stable/react@18.3.1/es2022/react.mjs");
-    assertEquals(res.headers.get("X-TypeScript-Types"), "http://localhost:8080/v128/@types/react@~18.3/index.d.ts");
-    assertStringIncludes(await res.text(), "/stable/react@18.3.1/es2022/react.mjs");
+    res.body?.cancel();
+    assertEquals(res.status, 301);
+    assert(res.headers.get("Location")?.startsWith("http://localhost:8080/react@18.3.1"));
   }
   {
-    const res = await fetch("http://localhost:8080/v135/react-dom@18.3.1", {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-      },
+    const res = await fetch("http://localhost:8080/v135/react@18.3.1", {
+      redirect: "manual",
     });
-    assertEquals(res.status, 200);
-    assertEquals(res.headers.get("Content-Type"), "application/javascript; charset=utf-8");
-    assertEquals(res.headers.get("X-Esm-Id"), "v135/react-dom@18.3.1/es2022/react-dom.mjs");
-    assertEquals(res.headers.get("X-TypeScript-Types"), "http://localhost:8080/v135/@types/react-dom@~18.3/index.d.ts");
-    assertStringIncludes(await res.text(), "/v135/react-dom@18.3.1/es2022/react-dom.mjs");
+    res.body?.cancel();
+    assertEquals(res.status, 301);
+    assert(res.headers.get("Location")?.startsWith("http://localhost:8080/react@18.3.1"));
   }
   {
     const res = await fetch("http://localhost:8080/stable/react", {
@@ -133,150 +130,41 @@ Deno.test("legacy routes", async () => {
     assert(res.headers.get("Location")?.startsWith("http://localhost:8080/stable/react@"));
   }
   {
-    const res = await fetch("http://localhost:8080/v135/react", {
+    const res = await fetch("http://localhost:8080/v135/react@18", {
       redirect: "manual",
     });
     res.body?.cancel();
     assertEquals(res.status, 302);
-    assert(res.headers.get("Location")?.startsWith("http://localhost:8080/v135/react@"));
-  }
-  {
-    const res = await fetch("http://localhost:8080/v135/@emotion/sheet?external=react,react-dom", {
-      redirect: "manual",
-    });
-    res.body?.cancel();
-    assertEquals(res.status, 302);
-    assert(res.headers.get("Location")?.startsWith("http://localhost:8080/v135/@emotion/sheet@"));
-    assert(res.headers.get("Location")?.endsWith("?external=react,react-dom"));
-  }
-  {
-    const res = await fetch("http://localhost:8080/v135/react-dom@19.0.0/client?external=*");
-    assertEquals(res.status, 200);
-    assertStringIncludes(await res.text(), "/v135/react-dom@19.0.0/X-ZS8q/denonext/client.js");
-  }
-  {
-    const res = await fetch("http://localhost:8080/*react-dom@19.0.0/client?pin=v135");
-    assertEquals(res.status, 200);
-    assertStringIncludes(await res.text(), "/v135/react-dom@19.0.0/X-ZS8q/denonext/client.js");
-  }
-  {
-    const res = await fetch("http://localhost:8080/v135/*react-dom@19.0.0/client");
-    assertEquals(res.status, 200);
-    assertStringIncludes(await res.text(), "/v135/react-dom@19.0.0/X-ZS8q/denonext/client.js");
-  }
-  {
-    const res = await fetch("http://localhost:8080/v135/*react-dom@19/client", {
-      redirect: "manual",
-    });
-    res.body?.cancel();
-    assertEquals(res.status, 302);
-    assert(res.headers.get("Location")?.startsWith("http://localhost:8080/v135/*react-dom@19."));
-  }
-  {
-    const res = await fetch("http://localhost:8080/v135/@types/react-dom@~18.3/index.d.ts", {
-      redirect: "manual",
-    });
-    res.body?.cancel();
-    assertEquals(res.status, 302);
-    assert(/^http:\/\/localhost:8080\/v135\/@types\/react-dom@18\.3\.\d\/index\.d\.ts$/.test(res.headers.get("Location")!));
-  }
-  {
-    const res = await fetch("http://localhost:8080/v135/@types/react-dom@18.3.1/index.d.ts");
-    assertEquals(res.status, 200);
-    assertEquals(res.headers.get("Content-Type"), "application/typescript; charset=utf-8");
-    assertStringIncludes(await res.text(), "http://localhost:8080/v135/@types/react@18.");
-  }
-  {
-    const res = await fetch("http://localhost:8080/v135/@types/react-modal@3.16.3/X-ZS8q/index.d.ts");
-    assertEquals(res.status, 200);
-    assertEquals(res.headers.get("Content-Type"), "application/typescript; charset=utf-8");
-    assertStringIncludes(await res.text(), "http://localhost:8080/v135/@types/react@");
-  }
-  {
-    const res = await fetch("http://localhost:8080/v135/@types/react-modal@3.16.3/X-ZS8q/index.d.ts");
-    assertEquals(res.status, 200);
-    assertEquals(res.headers.get("Content-Type"), "application/typescript; charset=utf-8");
-    assertStringIncludes(await res.text(), "http://localhost:8080/v135/@types/react@");
-  }
-  {
-    const res = await fetch("http://localhost:8080/v135/@types/react-modal@3.16.3/X-ZS8q/index.d.ts");
-    assertEquals(res.status, 200);
-    assertEquals(res.headers.get("Content-Type"), "application/typescript; charset=utf-8");
-    assertStringIncludes(await res.text(), "http://localhost:8080/v135/@types/react@");
-  }
-  {
-    const res = await fetch("http://localhost:8080/v135/@types/react-dom@~18.3/client~.d.ts", {
-      redirect: "manual",
-    });
-    res.body?.cancel();
-    assertEquals(res.status, 302);
-    assert(/^http:\/\/localhost:8080\/v135\/@types\/react-dom@18\.3\.\d\/client~\.d\.ts$/.test(res.headers.get("Location")!));
-  }
-  {
-    const res = await fetch("http://localhost:8080/v135/@types/react-dom@18.3.1/client~.d.ts");
-    assertEquals(res.status, 200);
-    assertEquals(res.headers.get("Content-Type"), "application/typescript; charset=utf-8");
-    assertStringIncludes(await res.text(), "createRoot");
-  }
-  {
-    const res = await fetch("http://localhost:8080/stable/react@18.3.1/es2022/react.mjs", {
-      headers: { "User-Agent": "i'm a browser" },
-    });
-    assertEquals(res.status, 200);
-    assertEquals(res.headers.get("Content-Type"), "application/javascript; charset=utf-8");
-    assertStringIncludes(await res.text(), "createElement");
-  }
-  {
-    const res = await fetch("http://localhost:8080/v135/react-dom@18.3.1/es2022/client.js", {
-      headers: { "User-Agent": "i'm a browser" },
-    });
-    assertEquals(res.status, 200);
-    assertEquals(res.headers.get("Content-Type"), "application/javascript; charset=utf-8");
-    assertStringIncludes(await res.text(), "createRoot");
-  }
-  {
-    const res = await fetch("http://localhost:8080/v64/many-keys-weakmap@1.0.0/es2022/many-keys-weakmap.js", {
-      headers: { "User-Agent": "i'm a browser" },
-    });
-    assertEquals(res.status, 200);
-    assertEquals(res.headers.get("Content-Type"), "application/javascript; charset=utf-8");
-    assertStringIncludes(await res.text(), "ManyKeysWeakMap");
+    assert(res.headers.get("Location")?.startsWith("http://localhost:8080/v135/react@18."));
   }
   {
     const res = await fetch("http://localhost:8080/v135/node_process.js", {
       headers: { "User-Agent": "i'm a browser" },
+      redirect: "manual",
     });
-    assertEquals(res.status, 200);
-    assertEquals(res.headers.get("Content-Type"), "application/javascript; charset=utf-8");
-    assertStringIncludes(await res.text(), "platform");
+    res.body?.cancel();
+    assertEquals(res.status, 301);
+    assert(res.headers.get("Location")?.startsWith("http://localhost:8080/node/process.mjs"));
   }
   {
     const res = await fetch("http://localhost:8080/v135/node.ns.d.ts", {
       headers: { "User-Agent": "Deno/1.42.0" },
     });
-    assertEquals(res.status, 200);
-    assertEquals(res.headers.get("Content-Type"), "application/typescript; charset=utf-8");
-    assertStringIncludes(await res.text(), "declare class Buffer extends Uint8Array");
+    await res.body?.cancel();
+    assertEquals(res.status, 404);
   }
   {
     // invalid build version
     const res = await fetch("http://localhost:8080/v136/react-dom@18.3.1/es2022/client.js", {
       headers: { "User-Agent": "i'm a browser" },
     });
-    res.body?.cancel();
+    await res.body?.cancel();
     assertEquals(res.status, 400);
   }
-  {
-    // respect legacy redirects
-    const res = await fetch("http://localhost:8080/v135/@jitl/quickjs-ng-wasmfile-release-sync@0.31.0/es2022/emscripten-module.wasm", {
-      headers: { "User-Agent": "i'm a browser" },
-      redirect: "manual",
-    });
-    res.body?.cancel();
-    assertEquals(res.status, 301);
-    assertEquals(
-      res.headers.get("Location"),
-      "http://localhost:8080/@jitl/quickjs-ng-wasmfile-release-sync@0.31.0/dist/emscripten-module.wasm",
-    );
-  }
 });
+
+async function writeTextFile(path: string, content: string) {
+  const dir = path.split("/").slice(0, -1).join("/");
+  await Deno.mkdir(dir, { recursive: true });
+  await Deno.writeTextFile(path, content);
+}


### PR DESCRIPTION
previous builds remain to work. new routes will be redirect to the new routes:

```
https://esm.sh/v135/react-dom@19.2.5 -> https://esm.sh/react-dom@19.2.5 
https://esm.sh/react-dom@19.2.5?pin=v135 -> https://esm.sh/react-dom@19.2.5 
```