### PR TITLE
fix(build): treat empty .mjs/.mts entry as ESM, not fake CJS

### DIFF
--- a/server/build_resolver.go
+++ b/server/build_resolver.go
@@ -1406,6 +1406,16 @@ func validateJSFile(filename string) (isESM bool, namedExports []string, err err
 		return
 	}
 	isESM = ast.ExportsKind == js_ast.ExportsESM || ast.ExportsKind == js_ast.ExportsESMWithDynamicFallback
+	// A module with no import/export/CommonJS markers (e.g. an empty file that
+	// contains only comments, as shipped by some types-only packages) is parsed
+	// as `ExportsNone`. For explicit ES module files (`.mjs`/`.mts`) such a file
+	// is still a valid—if empty—ES module and must be treated as ESM. Otherwise
+	// it would be misclassified as a "fake CommonJS module" and handed to the
+	// cjs-module-lexer, which can panic while resolving the entry's `exports`
+	// subpath under non-matching conditions (e.g. a `browser`-only build).
+	if !isESM && ast.ExportsKind == js_ast.ExportsNone && endsWith(filename, ".mjs", ".mts") {
+		isESM = true
+	}
 	namedExports = make([]string, len(ast.NamedExports))
 	i := 0
 	for name := range ast.NamedExports {

--- a/test/empty-mjs-module/test.ts
+++ b/test/empty-mjs-module/test.ts
@@ -1,0 +1,25 @@
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert";
+
+// A types-only package whose compiled runtime JS is intentionally empty
+// (only source-map comments, no import/export/CommonJS markers). The empty
+// `.mjs` entry parses as `ExportsKind == ExportsNone`, which used to be
+// misclassified as a "fake CommonJS module" and handed to cjs-module-lexer.
+// The lexer then panicked resolving the `browser`-only `exports` subpath under
+// `node`/`require` conditions, surfacing as an HTTP 500.
+//
+// related issue: https://github.com/esm-dev/esm.sh/issues/PENDING
+Deno.test("empty .mjs module (types-only package) builds instead of 500", async () => {
+  const res = await fetch(
+    "http://localhost:8080/@solana/rpc-parsed-types@6.9.0?target=esnext",
+    { headers: { "User-Agent": "i'm a browser" } },
+  );
+  const js = await res.text();
+  assertEquals(res.status, 200);
+  assertEquals(
+    res.headers.get("content-type"),
+    "application/javascript; charset=utf-8",
+  );
+  // The build should succeed and emit a (possibly empty) ES module rather than
+  // panicking in cjs-module-lexer.
+  assertStringIncludes(js, "/@solana/rpc-parsed-types@6.9.0/");
+});


### PR DESCRIPTION
Fixes https://github.com/esm-dev/esm.sh/issues/1365

A module with no import/export/CommonJS markers (e.g. an empty file that only contains comments, as shipped by some types-only packages such as @solana/rpc-parsed-types) is parsed by esbuild as ExportsNone. validateJSFile only classified ExportsESM/ExportsESMWithDynamicFallback as ESM, so such a file was misclassified as a 'fake CommonJS module' and handed to cjs-module-lexer. The lexer then panicked resolving the entry's exports subpath (e.g. a browser-only ./dist/index.browser.mjs) under node/require conditions, surfacing as an HTTP 500.

Treat ExportsNone for explicit ESM file extensions (.mjs/.mts) as ESM. This is safe because real CommonJS modules reference module/exports/require, which esbuild detects as ExportsCommonJS (never ExportsNone); only genuinely empty modules reach this branch, and for .mjs/.mts those are unambiguously ESM.

Fixes building @solana/kit and @solana-program/* packages, which transitively depend on the empty-runtime @solana/rpc-parsed-types.

Adds test/empty-mjs-module integration test.