### PR TITLE
Harden module resolution, registry auth, and web path handling

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -1198,6 +1198,15 @@ REBUILD:
 				return
 			}
 			name := strings.Split(msg, "\"")[1]
+			// a relative path import can not be externalized, report it as a build error
+			if isRelPathSpecifier(name) || strings.HasPrefix(name, "/") {
+				if loc := res.Errors[0].Location; loc != nil {
+					err = fmt.Errorf("could not resolve \"%s\" (imported by %s)", name, loc.File)
+				} else {
+					err = fmt.Errorf("could not resolve \"%s\"", name)
+				}
+				return
+			}
 			if !implicitExternal.Has(name) {
 				ctx.logger.Warnf("build(%s): implicit external '%s'", ctx.Path(), name)
 				implicitExternal.Add(name)

--- a/server/build_resolver.go
+++ b/server/build_resolver.go
@@ -701,6 +701,13 @@ func (ctx *BuildContext) resolveExternalModule(specifier string, kind esbuild.Re
 		return
 	}
 
+	// a relative path specifier is not a valid external module, and would be
+	// mis-parsed as an npm package named ".." by the dependency resolver below
+	if isRelPathSpecifier(specifier) {
+		err = errors.New("could not resolve \"" + specifier + "\"")
+		return
+	}
+
 	// return the specifier directly in analyze mode
 	if analyzeMode {
 		resolvedPath = specifier

--- a/server/git.go
+++ b/server/git.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"os/exec"
 	"time"
 
@@ -88,5 +89,10 @@ func ghInstallContext(ctx context.Context, wd, name, tag string) (err error) {
 	}
 
 	err = extractPackageTarballContext(ctx, wd, name, io.LimitReader(res.Body, maxPackageTarballSize))
+	if err != nil {
+		// clear wd if failed to extract tarball, otherwise the partial
+		// extraction would be treated as a completed installation
+		os.RemoveAll(wd)
+	}
 	return
 }

--- a/server/npmrc.go
+++ b/server/npmrc.go
@@ -590,10 +590,40 @@ func (reg *NpmRegistry) isSupportVersionRoute(urlStr string) bool {
 	return false
 }
 
+func sameURLOrigin(a *url.URL, b *url.URL) bool {
+	if !strings.EqualFold(a.Scheme, b.Scheme) || !strings.EqualFold(a.Hostname(), b.Hostname()) {
+		return false
+	}
+	aPort, bPort := a.Port(), b.Port()
+	if aPort == bPort {
+		return true
+	}
+	if strings.EqualFold(a.Scheme, "http") {
+		return aPort == "" && bPort == "80" || aPort == "80" && bPort == ""
+	}
+	return strings.EqualFold(a.Scheme, "https") && (aPort == "" && bPort == "443" || aPort == "443" && bPort == "")
+}
+
 func fetchPackageTarballContext(ctx context.Context, reg *NpmRegistry, installDir string, pkgName string, tarballUrlStr string) (err error) {
 	tarballUrl, err := url.Parse(tarballUrlStr)
 	if err != nil {
 		return
+	}
+	registryUrls := make([]*url.URL, 0, 2)
+	for _, urlStr := range [...]string{reg.Registry, reg.BackupRegistry} {
+		if urlStr != "" {
+			if u, parseErr := url.Parse(urlStr); parseErr == nil {
+				registryUrls = append(registryUrls, u)
+			}
+		}
+	}
+	isTrustedOrigin := func(u *url.URL) bool {
+		for _, registryUrl := range registryUrls {
+			if sameURLOrigin(u, registryUrl) {
+				return true
+			}
+		}
+		return false
 	}
 
 	if reg.isRateLimited() && reg.BackupRegistry != "" && strings.HasPrefix(tarballUrlStr, reg.Registry) {
@@ -609,13 +639,22 @@ func fetchPackageTarballContext(ctx context.Context, reg *NpmRegistry, installDi
 	}
 
 	header := http.Header{}
-	if reg.Token != "" {
-		header.Set("Authorization", "Bearer "+reg.Token)
-	} else if reg.User != "" && reg.Password != "" {
-		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(reg.User+":"+reg.Password)))
+	if isTrustedOrigin(tarballUrl) {
+		if reg.Token != "" {
+			header.Set("Authorization", "Bearer "+reg.Token)
+		} else if reg.User != "" && reg.Password != "" {
+			header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(reg.User+":"+reg.Password)))
+		}
 	}
 
 	fetchClient := fetch.NewClient("esmd/"+VERSION, 30, false)
+	checkRedirect := fetchClient.CheckRedirect
+	fetchClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if !isTrustedOrigin(req.URL) {
+			req.Header.Del("Authorization")
+		}
+		return checkRedirect(req, via)
+	}
 
 	retryTimes := 0
 RETRY:

--- a/server/npmrc_test.go
+++ b/server/npmrc_test.go
@@ -4,12 +4,104 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+func TestSameURLOrigin(t *testing.T) {
+	registryUrl, _ := url.Parse("https://registry.example/package")
+	for _, test := range []struct {
+		url  string
+		want bool
+	}{
+		{"https://registry.example/tarball.tgz", true},
+		{"https://REGISTRY.EXAMPLE:443/tarball.tgz", true},
+		{"http://registry.example/tarball.tgz", false},
+		{"https://registry.example:444/tarball.tgz", false},
+		{"https://tarballs.example/tarball.tgz", false},
+	} {
+		tarballUrl, _ := url.Parse(test.url)
+		if got := sameURLOrigin(registryUrl, tarballUrl); got != test.want {
+			t.Errorf("sameURLOrigin(%q, %q) = %v, want %v", registryUrl, tarballUrl, got, test.want)
+		}
+	}
+}
+
+func TestFetchPackageTarballAuthorization(t *testing.T) {
+	var tarball bytes.Buffer
+	gw := gzip.NewWriter(&tarball)
+	tw := tar.NewWriter(gw)
+	content := []byte(`{"name":"test-package","version":"1.0.0"}`)
+	if err := tw.WriteHeader(&tar.Header{Name: "package/package.json", Mode: 0644, Size: int64(len(content))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	authorization := make(chan string, 1)
+	tarballServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization <- r.Header.Get("Authorization")
+		_, _ = w.Write(tarball.Bytes())
+	}))
+	defer tarballServer.Close()
+
+	basicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:password"))
+	for _, test := range []struct {
+		name     string
+		registry NpmRegistryConfig
+		want     string
+	}{
+		{"same-origin bearer token", NpmRegistryConfig{Registry: tarballServer.URL + "/", Token: "secret"}, "Bearer secret"},
+		{"cross-origin bearer token", NpmRegistryConfig{Registry: "https://registry.example/", Token: "secret"}, ""},
+		{"same-origin basic auth", NpmRegistryConfig{Registry: tarballServer.URL + "/", User: "user", Password: "password"}, basicAuth},
+		{"cross-origin basic auth", NpmRegistryConfig{Registry: "https://registry.example/", User: "user", Password: "password"}, ""},
+		{"backup registry", NpmRegistryConfig{Registry: "https://registry.example/", BackupRegistry: tarballServer.URL + "/", Token: "secret"}, "Bearer secret"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			reg := &NpmRegistry{NpmRegistryConfig: test.registry}
+			if err := fetchPackageTarballContext(context.Background(), reg, t.TempDir(), "test-package", tarballServer.URL+"/test-package.tgz"); err != nil {
+				t.Fatal(err)
+			}
+			if got := <-authorization; got != test.want {
+				t.Fatalf("expected Authorization header %q, got %q", test.want, got)
+			}
+		})
+	}
+
+	redirectAuthorization := make(chan string, 1)
+	crossOriginServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectAuthorization <- r.Header.Get("Authorization")
+		_, _ = w.Write(tarball.Bytes())
+	}))
+	defer crossOriginServer.Close()
+	registryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, crossOriginServer.URL+"/test-package.tgz", http.StatusFound)
+	}))
+	defer registryServer.Close()
+
+	reg := &NpmRegistry{NpmRegistryConfig: NpmRegistryConfig{Registry: registryServer.URL + "/", Token: "secret"}}
+	if err := fetchPackageTarballContext(context.Background(), reg, t.TempDir(), "test-package", registryServer.URL+"/test-package.tgz"); err != nil {
+		t.Fatal(err)
+	}
+	if got := <-redirectAuthorization; got != "" {
+		t.Fatalf("expected redirect to strip Authorization header, got %q", got)
+	}
+}
 
 func TestExtractPackageTarball(t *testing.T) {
 	b := make([]byte, 16)

--- a/web/handler.go
+++ b/web/handler.go
@@ -61,6 +61,11 @@ func NewHandler(config Config) *Handler {
 
 func (s *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	pathname := r.URL.Path
+	localPath := filepath.FromSlash(strings.TrimPrefix(pathname, "/"))
+	if strings.IndexByte(localPath, 0) >= 0 || (localPath != "" && !filepath.IsLocal(localPath)) {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
 	switch pathname {
 	case "/@hmr", "/@refresh", "/@prefresh", "/@vdr":
 		s.ServeInternalJS(w, r, pathname[2:])
@@ -71,7 +76,7 @@ func (s *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		s.ServeHmrWS(w, r)
 	default:
-		filename := filepath.Join(s.config.AppDir, pathname)
+		filename := filepath.Join(s.config.AppDir, localPath)
 		fi, err := os.Lstat(filename)
 		if err == nil && fi.IsDir() {
 			if pathname != "/" && !strings.HasSuffix(pathname, "/") {


### PR DESCRIPTION
## Summary
- Reject unresolved relative and absolute imports instead of treating them as external packages.
- Restrict npm credentials to trusted registry origins and strip them on cross-origin redirects.
- Remove partially extracted GitHub packages after extraction failures.
- Validate web request paths to prevent invalid or unsafe filesystem access.
- Add coverage for registry origins, authorization behavior, and redirects.

## Testing
- Added unit tests for URL origin matching and tarball authorization handling.
- Not run (not requested)