### PR TITLE
Prevent package metadata path traversal

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -298,7 +298,12 @@ func (ctx *BuildContext) buildModule(analyzeMode bool) (meta *BuildMeta, include
 			return
 		}
 		var jsonData []byte
-		jsonPath := path.Join(ctx.wd, "node_modules", ctx.esmPath.PkgName, entry.main)
+		pkgDir := path.Join(ctx.wd, "node_modules", ctx.esmPath.PkgName)
+		jsonPath := path.Join(pkgDir, entry.main)
+		if !strings.HasPrefix(jsonPath, pkgDir+"/") {
+			err = fmt.Errorf("could not resolve module %s", entry.main)
+			return
+		}
 		jsonData, err = os.ReadFile(jsonPath)
 		if err != nil {
 			return

--- a/server/build_test.go
+++ b/server/build_test.go
@@ -1,0 +1,87 @@
+package server
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/esm-dev/esm.sh/internal/npm"
+	"github.com/esm-dev/esm.sh/internal/storage"
+)
+
+func TestBuildModuleJSONPathTraversal(t *testing.T) {
+	root := t.TempDir()
+	wd := filepath.Join(root, "wd")
+	pkgName := "traversal-pkg"
+	pkgDir := filepath.Join(wd, "node_modules", pkgName)
+	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wd, "secret.json"), []byte(`{"secret":true}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "data.json"), []byte(`{"safe":true}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fs, err := storage.NewFSStorage(filepath.Join(root, "storage"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkgJson := &npm.PackageJSON{Name: pkgName, Version: "1.0.0"}
+
+	ctx := &BuildContext{
+		storage: fs,
+		wd:      wd,
+		esmPath: EsmPath{
+			PkgName:    pkgName,
+			PkgVersion: "1.0.0",
+			SubPath:    "../../secret.json",
+		},
+		pkgJson: pkgJson,
+		path:    "traversal.mjs",
+	}
+	meta, _, err := ctx.buildModule(false)
+	if err == nil {
+		t.Fatal("expected path traversal to be rejected")
+	}
+	if meta != nil {
+		t.Fatal("expected no build metadata")
+	}
+	if _, err := fs.Stat(ctx.getSavePath()); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("expected no cached module, got %v", err)
+	}
+
+	ctx = &BuildContext{
+		storage: fs,
+		wd:      wd,
+		esmPath: EsmPath{
+			PkgName:    pkgName,
+			PkgVersion: "1.0.0",
+			SubPath:    "data.json",
+		},
+		pkgJson: pkgJson,
+		path:    "valid.mjs",
+	}
+	meta, _, err = ctx.buildModule(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta == nil || !meta.ExportDefault {
+		t.Fatal("expected a JSON module with a default export")
+	}
+	f, _, err := fs.Get(ctx.getSavePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	data, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `export default {"safe":true}` {
+		t.Fatalf("unexpected module output: %s", data)
+	}
+}


### PR DESCRIPTION
## Summary

- Validate resolved package metadata paths remain inside the package directory.
- Reject traversal attempts before reading files or caching generated modules.
- Add regression coverage for rejected traversal and valid JSON module loading.

## Testing

- Added and ran a unit test covering traversal rejection and safe JSON resolution.