### PR TITLE
Harden package resolution and routing

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -114,7 +114,8 @@ To deploy the server with CloudFlare CDN, you need to create following cache rul
 (ends_with(http.request.uri.path, ".d.cts"))
 ```
 
-Ensure "Ignore query string" option is enabled in the "cache key" settings.
+Keep the query string in the cache key. Do not enable "Ignore query string":
+`?module` and declaration build arguments can change the response body.
 
 #### 2. Cache `?target=*`
 

--- a/internal/npm/npm.go
+++ b/internal/npm/npm.go
@@ -21,7 +21,7 @@ var (
 // ValidatePackageName validates the package name.
 // based on https://github.com/npm/validate-npm-package-name
 func ValidatePackageName(pkgName string) bool {
-	if l := len(pkgName); l == 0 || l > 214 {
+	if l := len(pkgName); l == 0 || l > 214 || pkgName == "." || pkgName == ".." {
 		return false
 	}
 	if strings.HasSuffix(pkgName, ".d.ts.map") {
@@ -29,9 +29,38 @@ func ValidatePackageName(pkgName string) bool {
 	}
 	if strings.HasPrefix(pkgName, "@") {
 		scope, name := utils.SplitByFirstByte(pkgName, '/')
-		return Naming.Match(scope[1:]) && Naming.Match(name)
+		return name != "." && name != ".." && Naming.Match(scope[1:]) && Naming.Match(name)
 	}
 	return Naming.Match(pkgName)
+}
+
+// ValidatePkgPrNewName validates compact and repository-qualified pkg.pr.new names.
+func ValidatePkgPrNewName(pkgName string) bool {
+	if len(pkgName) == 0 || len(pkgName) > 512 {
+		return false
+	}
+	parts := strings.Split(pkgName, "/")
+	validSegment := func(segment string) bool {
+		return len(segment) <= 214 && segment != "." && segment != ".." && Naming.Match(segment)
+	}
+	switch len(parts) {
+	case 1:
+		return ValidatePackageName(pkgName)
+	case 2:
+		if strings.HasPrefix(pkgName, "@") {
+			return ValidatePackageName(pkgName)
+		}
+		return validSegment(parts[0]) && validSegment(parts[1])
+	case 3:
+		return validSegment(parts[0]) && validSegment(parts[1]) && ValidatePackageName(parts[2])
+	case 4:
+		return validSegment(parts[0]) && validSegment(parts[1]) && strings.HasPrefix(parts[2], "@") && ValidatePackageName(parts[2]+"/"+parts[3])
+	}
+	return false
+}
+
+func ValidatePkgPrNewVersion(version string) bool {
+	return len(version) <= 256 && version != "." && version != ".." && Versioning.Match(version)
 }
 
 type Package struct {
@@ -111,11 +140,11 @@ func ResolveDependencyVersion(v string) (Package, error) {
 		}
 		if u.Host == "pkg.pr.new" {
 			pkgName, rest := utils.SplitByLastByte(u.Path[1:], '@')
-			if rest == "" {
+			if rest == "" || !ValidatePkgPrNewName(pkgName) {
 				return Package{}, errors.New("unsupported http dependency")
 			}
 			version, _ := utils.SplitByFirstByte(rest, '/')
-			if version == "" {
+			if !ValidatePkgPrNewVersion(version) {
 				return Package{}, errors.New("unsupported http dependency")
 			}
 			return Package{

--- a/internal/npm/npm_test.go
+++ b/internal/npm/npm_test.go
@@ -5,6 +5,51 @@ import (
 	"time"
 )
 
+func TestValidatePkgPrNewName(t *testing.T) {
+	for _, name := range []string{
+		"tinybench",
+		"@scope/package",
+		"sveltejs/svelte",
+		"tinylibs/tinybench/tinybench",
+		"owner/repo/@scope/package",
+	} {
+		if !ValidatePkgPrNewName(name) {
+			t.Errorf("expected %q to be valid", name)
+		}
+	}
+
+	for _, name := range []string{
+		"",
+		".",
+		"..",
+		"owner/../package",
+		"owner//package",
+		"/owner/repo",
+		"owner/repo/",
+		"owner/repo/package/extra",
+		"owner/repo/@scope",
+		`owner\repo`,
+		"owner/repo/package?query",
+	} {
+		if ValidatePkgPrNewName(name) {
+			t.Errorf("expected %q to be invalid", name)
+		}
+	}
+}
+
+func TestValidatePkgPrNewVersion(t *testing.T) {
+	for _, version := range []string{"main", "123", "a832a55", "feature-1"} {
+		if !ValidatePkgPrNewVersion(version) {
+			t.Errorf("expected %q to be valid", version)
+		}
+	}
+	for _, version := range []string{"", ".", "..", "../main", "feature/main"} {
+		if ValidatePkgPrNewVersion(version) {
+			t.Errorf("expected %q to be invalid", version)
+		}
+	}
+}
+
 func TestIsExactVersion(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/server/build.go
+++ b/server/build.go
@@ -50,6 +50,7 @@ type BuildContext struct {
 	path        string
 	rawPath     string
 	status      string
+	onPathReady func() bool
 	splitting   *set.ReadOnlySet[string]
 	esmImports  [][2]string
 	cjsRequires [][3]string
@@ -159,6 +160,13 @@ func (ctx *BuildContext) Build(buildCtx context.Context) (meta *BuildMeta, err e
 	if err != nil {
 		return
 	}
+	err = ctx.normalizeBuildArgs()
+	if err != nil {
+		return
+	}
+	if ctx.onPathReady != nil && !ctx.onPathReady() {
+		return
+	}
 
 	// check previous build again after installation (in case the sub-module path has been changed by the `install` function)
 	meta, ok, err = ctx.Exists()
@@ -206,7 +214,7 @@ func (ctx *BuildContext) buildPath() {
 
 	esm := ctx.esmPath
 	if ctx.target == "types" {
-		if strings.HasSuffix(esm.SubPath, ".d.ts") {
+		if esm.SubPath != "" {
 			ctx.path = fmt.Sprintf(
 				"/%s%s/%s%s",
 				asteriskPrefix,
@@ -308,10 +316,12 @@ func (ctx *BuildContext) buildModule(analyzeMode bool) (meta *BuildMeta, include
 		if err != nil {
 			return
 		}
-		buffer := &bytes.Buffer{}
-		buffer.WriteString("export default ")
-		buffer.Write(jsonData)
-		err = ctx.storage.Put(ctx.getSavePath(), buffer)
+		var js []byte
+		js, err = encodeJSONModule(jsonData)
+		if err != nil {
+			return
+		}
+		err = ctx.storage.Put(ctx.getSavePath(), bytes.NewReader(js))
 		if err != nil {
 			ctx.logger.Errorf("storage.put(%s): %v", ctx.getSavePath(), err)
 			err = errors.New("storage(put): " + err.Error())
@@ -1559,6 +1569,13 @@ func (ctx *BuildContext) buildTypes() (ret *BuildMeta, err error) {
 	ctx.status = "install"
 	err = ctx.install()
 	if err != nil {
+		return
+	}
+	err = ctx.normalizeBuildArgs()
+	if err != nil {
+		return
+	}
+	if ctx.onPathReady != nil && !ctx.onPathReady() {
 		return
 	}
 	if err = ctx.checkCanceled(); err != nil {

--- a/server/build_args.go
+++ b/server/build_args.go
@@ -1,16 +1,24 @@
 package server
 
 import (
+	"encoding/base64"
+	"errors"
 	"fmt"
 	"maps"
 	"path"
-	"slices"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/esm-dev/esm.sh/internal/npm"
 	"github.com/ije/gox/set"
 	"github.com/ije/gox/utils"
+)
+
+const (
+	maxBuildArgBytes        = 4096
+	maxBuildArgItems        = 32
+	maxEncodedBuildArgBytes = 4*maxBuildArgBytes + 16
 )
 
 type BuildArgs struct {
@@ -23,32 +31,171 @@ type BuildArgs struct {
 	ExternalRequire   bool
 }
 
+func parseAliasArg(value string, maxBytes int) (map[string]string, error) {
+	alias := map[string]string{}
+	if len(value) > maxBytes {
+		return nil, fmt.Errorf("alias query exceeds %d bytes", maxBytes)
+	}
+	validSpecifier := func(specifier string) bool {
+		if len(specifier) > 512 || strings.ContainsAny(specifier, `\?#%&`) || strings.IndexFunc(specifier, unicode.IsControl) >= 0 {
+			return false
+		}
+		pkgName, pkgVersion, subPath := splitEsmPath(specifier)
+		if !npm.ValidatePackageName(pkgName) || len(pkgVersion) > 256 {
+			return false
+		}
+		if subPath != "" {
+			for segment := range strings.SplitSeq(subPath, "/") {
+				if len(segment) > 214 || segment == "" || segment == "." || segment == ".." || strings.ContainsRune(segment, '=') {
+					return false
+				}
+			}
+		}
+		return true
+	}
+	for p := range strings.SplitSeq(value, ",") {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		name, to := utils.SplitByFirstByte(p, ':')
+		name = strings.TrimSpace(name)
+		to = strings.TrimSpace(to)
+		if !validSpecifier(name) || !validSpecifier(to) {
+			return nil, fmt.Errorf("invalid alias %q", p)
+		}
+		if _, ok := alias[name]; !ok && len(alias) >= maxBuildArgItems {
+			return nil, fmt.Errorf("alias query exceeds %d entries", maxBuildArgItems)
+		}
+		alias[name] = to
+	}
+	return alias, nil
+}
+
+func parseDepsArg(value string, maxBytes int) (map[string]string, error) {
+	deps := map[string]string{}
+	if len(value) > maxBytes {
+		return nil, fmt.Errorf("deps query exceeds %d bytes", maxBytes)
+	}
+	for p := range strings.SplitSeq(value, ",") {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		pkgName, pkgVersion, subPath := splitEsmPath(p)
+		if !npm.ValidatePackageName(pkgName) || len(pkgVersion) > 256 || subPath != "" || strings.ContainsAny(pkgVersion, `\?#%&`) || strings.IndexFunc(pkgVersion, unicode.IsControl) >= 0 {
+			return nil, fmt.Errorf("invalid dependency %q", p)
+		}
+		if _, ok := deps[pkgName]; !ok && len(deps) >= maxBuildArgItems {
+			return nil, fmt.Errorf("deps query exceeds %d entries", maxBuildArgItems)
+		}
+		deps[pkgName] = pkgVersion
+	}
+	return deps, nil
+}
+
+func parseExternalArg(value string) (*set.Set[string], bool, error) {
+	external := set.New[string]()
+	if len(value) > maxBuildArgBytes {
+		return nil, false, fmt.Errorf("external query exceeds %d bytes", maxBuildArgBytes)
+	}
+	for p := range strings.SplitSeq(value, ",") {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if p == "*" {
+			return set.New[string](), true, nil
+		}
+		isNamespace := strings.HasPrefix(p, "@") && !strings.Contains(p[1:], "/") && npm.Naming.Match(p[1:])
+		if len(p) > 214 || (!npm.ValidatePackageName(p) && !isNamespace && !(strings.HasPrefix(p, "node:") && nodeBuiltinModules[p[5:]])) {
+			return nil, false, fmt.Errorf("invalid external %q", p)
+		}
+		if !external.Has(p) && external.Len() >= maxBuildArgItems {
+			return nil, false, fmt.Errorf("external query exceeds %d entries", maxBuildArgItems)
+		}
+		external.Add(p)
+	}
+	return external, false, nil
+}
+
+func parseConditionsArg(value string) ([]string, error) {
+	conditions := make([]string, 0)
+	seen := set.New[string]()
+	if len(value) > maxBuildArgBytes {
+		return nil, fmt.Errorf("conditions query exceeds %d bytes", maxBuildArgBytes)
+	}
+	for p := range strings.SplitSeq(value, ",") {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if len(p) > 128 || !npm.Versioning.Match(p) {
+			return nil, fmt.Errorf("invalid condition %q", p)
+		}
+		if !seen.Has(p) {
+			if len(conditions) >= maxBuildArgItems {
+				return nil, fmt.Errorf("conditions query exceeds %d entries", maxBuildArgItems)
+			}
+			seen.Add(p)
+			conditions = append(conditions, p)
+		}
+	}
+	return conditions, nil
+}
+
 func decodeBuildArgs(argsString string) (args BuildArgs, err error) {
-	s, err := atobUrl(strings.TrimPrefix(argsString, "X-"))
+	encoded := strings.TrimPrefix(argsString, "X-")
+	if len(encoded) > base64.RawURLEncoding.EncodedLen(maxEncodedBuildArgBytes) {
+		return args, fmt.Errorf("encoded build args exceed %d bytes", maxEncodedBuildArgBytes)
+	}
+	s, err := atobUrl(encoded)
 	if err == nil {
+		if len(s) > maxEncodedBuildArgBytes {
+			return args, fmt.Errorf("encoded build args exceed %d bytes", maxEncodedBuildArgBytes)
+		}
 		args = BuildArgs{}
+		seen := set.New[byte]()
 		for p := range strings.SplitSeq(s, "\n") {
-			if strings.HasPrefix(p, "a") {
-				args.Alias = map[string]string{}
-				for p := range strings.SplitSeq(p[1:], ",") {
-					name, to := utils.SplitByFirstByte(p, ':')
-					name = strings.TrimSpace(name)
-					to = strings.TrimSpace(to)
-					if name != "" && to != "" {
-						args.Alias[name] = to
-					}
+			if p == "" {
+				continue
+			}
+			key := p[0]
+			if key == 'C' {
+				key = 'c'
+			}
+			if strings.ContainsRune("adec", rune(key)) {
+				if seen.Has(key) {
+					return args, fmt.Errorf("duplicate encoded build arg %q", p[:1])
 				}
-			} else if strings.HasPrefix(p, "d") {
-				deps := map[string]string{}
-				for p := range strings.SplitSeq(p[1:], ",") {
-					pkgName, pkgVersion, _ := splitEsmPath(p)
-					deps[pkgName] = pkgVersion
+				seen.Add(key)
+			}
+			if p[0] == 'a' {
+				args.Alias, err = parseAliasArg(p[1:], maxEncodedBuildArgBytes)
+				if err != nil {
+					return
 				}
-				args.Deps = deps
-			} else if strings.HasPrefix(p, "e") {
-				args.External = *set.NewReadOnly(strings.Split(p[1:], ",")...)
-			} else if strings.HasPrefix(p, "c") {
-				args.Conditions = append(args.Conditions, strings.Split(p[1:], ",")...)
+			} else if p[0] == 'd' {
+				args.Deps, err = parseDepsArg(p[1:], maxEncodedBuildArgBytes)
+				if err != nil {
+					return
+				}
+			} else if p[0] == 'e' {
+				var external *set.Set[string]
+				var externalAll bool
+				external, externalAll, err = parseExternalArg(p[1:])
+				if err != nil {
+					return
+				}
+				if externalAll {
+					return args, errors.New("external all must use the path prefix")
+				}
+				args.External = *external.ReadOnly()
+			} else if p[0] == 'c' || p[0] == 'C' {
+				args.Conditions, err = parseConditionsArg(p[1:])
+				if err != nil {
+					return
+				}
 			} else {
 				switch p {
 				case "r":
@@ -57,7 +204,8 @@ func decodeBuildArgs(argsString string) (args BuildArgs, err error) {
 					args.KeepNames = true
 				case "i":
 					args.IgnoreAnnotations = true
-
+				default:
+					return args, fmt.Errorf("invalid encoded build arg %q", p)
 				}
 			}
 		}
@@ -98,14 +246,7 @@ func encodeBuildArgs(args BuildArgs, isDts bool) string {
 		}
 	}
 	if len(args.Conditions) > 0 {
-		var ss sort.StringSlice
-		for _, name := range args.Conditions {
-			ss = append(ss, name)
-		}
-		if len(ss) > 0 {
-			ss.Sort()
-			lines = append(lines, fmt.Sprintf("c%s", strings.Join(ss, ",")))
-		}
+		lines = append(lines, fmt.Sprintf("C%s", strings.Join(args.Conditions, ",")))
 	}
 	if !isDts {
 		if args.ExternalRequire {
@@ -124,9 +265,75 @@ func encodeBuildArgs(args BuildArgs, isDts bool) string {
 	return ""
 }
 
+func (ctx *BuildContext) normalizeBuildArgs() error {
+	if len(ctx.args.Alias) == 0 && len(ctx.args.Deps) == 0 && ctx.args.External.Len() == 0 {
+		return nil
+	}
+	rawPath := ctx.Path()
+	before := encodeBuildArgs(ctx.args, ctx.target == "types")
+	if err := resolveBuildArgs(ctx.npmrc, ctx.wd, &ctx.args, ctx.esmPath); err != nil {
+		return err
+	}
+	for name, version := range ctx.args.Deps {
+		p, err := ctx.npmrc.getPackageInfoContext(ctx.Context(), name, version)
+		if err != nil {
+			return err
+		}
+		ctx.args.Deps[name] = strings.TrimPrefix(p.Version, "v")
+	}
+	for from, to := range ctx.args.Alias {
+		name, version, subPath := splitEsmPath(to)
+		if version == "" {
+			if v, ok := ctx.args.Deps[name]; ok {
+				version = v
+			} else if ctx.pkgJson != nil {
+				if v, ok := ctx.pkgJson.Dependencies[name]; ok {
+					version = v
+				} else if v, ok := ctx.pkgJson.PeerDependencies[name]; ok {
+					version = v
+				}
+			}
+			if version != "" {
+				p, err := npm.ResolveDependencyVersion(version)
+				if err != nil {
+					return err
+				}
+				if p.Url != "" || p.Github || p.PkgPrNew {
+					continue
+				}
+				if p.Name != "" {
+					name = p.Name
+					version = p.Version
+				}
+			}
+		}
+		p, err := ctx.npmrc.getPackageInfoContext(ctx.Context(), name, version)
+		if err != nil {
+			return err
+		}
+		to = p.Name + "@" + strings.TrimPrefix(p.Version, "v")
+		if subPath != "" {
+			to += "/" + subPath
+		}
+		ctx.args.Alias[from] = to
+	}
+	after := encodeBuildArgs(ctx.args, ctx.target == "types")
+	if len(after) > base64.RawURLEncoding.EncodedLen(maxEncodedBuildArgBytes) {
+		return fmt.Errorf("encoded build args exceed %d bytes", maxEncodedBuildArgBytes)
+	}
+	if before != after {
+		if ctx.rawPath == "" {
+			ctx.rawPath = rawPath
+		}
+		ctx.path = ""
+	}
+	return nil
+}
+
 // resolveBuildArgs resolves `alias`, `deps`, `external` of the build args
 func resolveBuildArgs(npmrc *NpmRC, installDir string, args *BuildArgs, esm EsmPath) error {
 	if len(args.Alias) > 0 || len(args.Deps) > 0 || args.External.Len() > 0 {
+		subPathDeps := set.New(strings.Split(esm.SubPath, "/")...)
 		// quick check if the alias, deps, external are all in dependencies of the package
 		deps, ok, err := func() (deps *set.Set[string], ok bool, err error) {
 			var p *npm.PackageJSON
@@ -154,21 +361,21 @@ func resolveBuildArgs(npmrc *NpmRC, installDir string, args *BuildArgs, esm EsmP
 			}
 			if len(args.Alias) > 0 {
 				for from := range args.Alias {
-					if !deps.Has(from) {
+					if !deps.Has(from) && !subPathDeps.Has(from) {
 						return nil, false, nil
 					}
 				}
 			}
 			if len(args.Deps) > 0 {
 				for name := range args.Deps {
-					if !deps.Has(name) {
+					if !deps.Has(name) && !subPathDeps.Has(name) {
 						return nil, false, nil
 					}
 				}
 			}
 			if args.External.Len() > 0 {
 				for _, name := range args.External.Values() {
-					if !deps.Has(name) {
+					if !deps.Has(name) && !subPathDeps.Has(name) {
 						return nil, false, nil
 					}
 				}
@@ -188,7 +395,7 @@ func resolveBuildArgs(npmrc *NpmRC, installDir string, args *BuildArgs, esm EsmP
 		if len(args.Alias) > 0 {
 			alias := map[string]string{}
 			for from, to := range args.Alias {
-				if deps.Has(from) {
+				if deps.Has(from) || subPathDeps.Has(from) {
 					alias[from] = to
 				}
 			}
@@ -205,14 +412,9 @@ func resolveBuildArgs(npmrc *NpmRC, installDir string, args *BuildArgs, esm EsmP
 		if len(args.Deps) > 0 {
 			depsArg := map[string]string{}
 			for name, version := range args.Deps {
-				if name != esm.PkgName && deps.Has(name) {
-					depsArg[name] = version
-					continue
-				}
-				// fix some edge cases
-				// for example, the package "htm" doesn't declare 'preact' as a dependency explicitly
-				// as a workaround, we check if the package name is in the subPath of the package
-				if esm.SubPath != "" && slices.Contains(strings.Split(esm.SubPath, "/"), name) {
+				// Some submodules import an undeclared package matching their name,
+				// for example "htm/preact".
+				if name != esm.PkgName && (deps.Has(name) || subPathDeps.Has(name)) {
 					depsArg[name] = version
 				}
 			}
@@ -230,14 +432,16 @@ func resolveBuildArgs(npmrc *NpmRC, installDir string, args *BuildArgs, esm EsmP
 				// Check if this is a namespace pattern (e.g., @radix-ui)
 				isNamespace := strings.HasPrefix(name, "@") && !strings.Contains(name[1:], "/")
 				if isNamespace {
-					// Add all packages from this namespace that are in deps
+					matched := false
 					for _, dep := range deps.Values() {
 						if strings.HasPrefix(dep, name+"/") {
-							external = append(external, dep)
+							matched = true
+							break
 						}
 					}
-					// Also keep the namespace itself in external for pattern matching
-					external = append(external, name)
+					if matched {
+						external = append(external, name)
+					}
 					continue
 				}
 				// if the subModule externalizes the package entry
@@ -245,7 +449,7 @@ func resolveBuildArgs(npmrc *NpmRC, installDir string, args *BuildArgs, esm EsmP
 					external = append(external, name)
 					continue
 				}
-				if name != esm.PkgName && deps.Has(name) {
+				if name != esm.PkgName && (deps.Has(name) || subPathDeps.Has(name)) {
 					external = append(external, name)
 				}
 			}

--- a/server/build_args_test.go
+++ b/server/build_args_test.go
@@ -1,10 +1,122 @@
 package server
 
 import (
+	"encoding/base64"
+	"fmt"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"slices"
+	"strings"
 	"testing"
 
+	"github.com/esm-dev/esm.sh/internal/npm"
 	"github.com/ije/gox/set"
 )
+
+func TestParseBuildArgs(t *testing.T) {
+	aliases := make([]string, maxBuildArgItems)
+	deps := make([]string, maxBuildArgItems)
+	for i := range maxBuildArgItems {
+		aliases[i] = fmt.Sprintf("package%d:target%d/subpath", i, i)
+		deps[i] = fmt.Sprintf("package%d@1.0.%d", i, i)
+	}
+	if _, err := parseAliasArg(strings.Join(aliases, ","), maxBuildArgBytes); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseDepsArg(strings.Join(deps, ","), maxBuildArgBytes); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := parseExternalArg("react,@radix-ui,node:fs"); err != nil {
+		t.Fatal(err)
+	}
+	if conditions, err := parseConditionsArg("browser,react-server,browser"); err != nil || len(conditions) != 2 {
+		t.Fatalf("unexpected conditions: %v, %v", conditions, err)
+	}
+	if _, err := parseAliasArg("react/jsx-runtime:preact/jsx-runtime,react:preact@>=10", maxBuildArgBytes); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseDepsArg("react@>=18", maxBuildArgBytes); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseAliasArg(strings.Join(append(aliases, "extra:target"), ","), maxBuildArgBytes); err == nil {
+		t.Fatal("expected too many aliases to be rejected")
+	}
+	if _, err := parseDepsArg(strings.Join(append(deps, "extra@1.0.0"), ","), maxBuildArgBytes); err == nil {
+		t.Fatal("expected too many dependencies to be rejected")
+	}
+	if _, err := parseAliasArg(strings.Repeat("a", maxBuildArgBytes+1), maxBuildArgBytes); err == nil {
+		t.Fatal("expected oversized aliases to be rejected")
+	}
+	if _, err := parseDepsArg(strings.Repeat("a", maxBuildArgBytes+1), maxBuildArgBytes); err == nil {
+		t.Fatal("expected oversized dependencies to be rejected")
+	}
+	if _, _, err := parseExternalArg(strings.Repeat("a", maxBuildArgBytes+1)); err == nil {
+		t.Fatal("expected oversized externals to be rejected")
+	}
+	if _, err := parseConditionsArg(strings.Repeat("a", maxBuildArgBytes+1)); err == nil {
+		t.Fatal("expected oversized conditions to be rejected")
+	}
+
+	externals := make([]string, maxBuildArgItems+1)
+	conditions := make([]string, maxBuildArgItems+1)
+	for i := range externals {
+		externals[i] = fmt.Sprintf("external%d", i)
+		conditions[i] = fmt.Sprintf("condition%d", i)
+	}
+	if _, _, err := parseExternalArg(strings.Join(externals, ",")); err == nil {
+		t.Fatal("expected too many externals to be rejected")
+	}
+	if _, err := parseConditionsArg(strings.Join(conditions, ",")); err == nil {
+		t.Fatal("expected too many conditions to be rejected")
+	}
+
+	for _, value := range []string{
+		"../react:preact",
+		"react:../../preact",
+		"react:https://example.com/preact",
+		"react:preact?dev",
+		"react:preact%2fcompat",
+		"react:preact/compat&external=*",
+		"react:preact/compat=other",
+	} {
+		if _, err := parseAliasArg(value, maxBuildArgBytes); err == nil {
+			t.Errorf("expected alias %q to be rejected", value)
+		}
+	}
+	for _, value := range []string{"../react@1.0.0", "react@1.0.0/subpath", "react@1.0.0?dev", "react@1.0.0&external=*"} {
+		if _, err := parseDepsArg(value, maxBuildArgBytes); err == nil {
+			t.Errorf("expected dependency %q to be rejected", value)
+		}
+	}
+	for _, value := range []string{"../react", "@bad/scope/extra", "node:not-a-builtin"} {
+		if _, _, err := parseExternalArg(value); err == nil {
+			t.Errorf("expected external %q to be rejected", value)
+		}
+	}
+	for _, value := range []string{"bad condition", "bad\ncondition", "bad/condition", "browser&external=*", "quoted\"condition", "`template`"} {
+		if _, err := parseConditionsArg(value); err == nil {
+			t.Errorf("expected condition %q to be rejected", value)
+		}
+	}
+
+	parsed, err := parseDepsArg("react@18.2.0,react@19.0.0", maxBuildArgBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed) != 1 || parsed["react"] != "19.0.0" {
+		t.Fatalf("unexpected duplicate dependency result: %#v", parsed)
+	}
+
+	if _, err := decodeBuildArgs("X-" + btoaUrl("a"+strings.Repeat("a", maxBuildArgBytes+1))); err == nil {
+		t.Fatal("expected an oversized encoded alias to be rejected")
+	}
+	if _, err := decodeBuildArgs("X-" + btoaUrl(strings.Repeat("r", maxEncodedBuildArgBytes+1))); err == nil {
+		t.Fatal("expected oversized encoded build args to be rejected")
+	}
+}
 
 func TestEncodeBuildArgs(t *testing.T) {
 	conditions := []string{"react-server"}
@@ -48,5 +160,243 @@ func TestEncodeBuildArgs(t *testing.T) {
 	}
 	if !args.IgnoreAnnotations {
 		t.Fatal("ignoreAnnotations should be true")
+	}
+
+	reversedConditions := encodeBuildArgs(BuildArgs{Conditions: []string{"worker", "react-server"}}, false)
+	if reversedConditions == encodeBuildArgs(BuildArgs{Conditions: []string{"react-server", "worker"}}, false) {
+		t.Fatal("condition order must be part of the build key")
+	}
+	if reversedConditions == btoaUrl("cworker,react-server") {
+		t.Fatal("condition builds must not reuse legacy cache keys")
+	}
+	legacy, err := decodeBuildArgs("X-" + btoaUrl("cworker,react-server"))
+	if err != nil || !slices.Equal(legacy.Conditions, []string{"worker", "react-server"}) {
+		t.Fatalf("failed to decode legacy conditions: %#v, %v", legacy.Conditions, err)
+	}
+	if _, err := decodeBuildArgs("X-" + btoaUrl("cworker\nCreact-server")); err == nil {
+		t.Fatal("mixed legacy and current conditions must be rejected")
+	}
+
+	longAliases := make(map[string]string, maxBuildArgItems)
+	for i := range maxBuildArgItems {
+		longAliases[fmt.Sprintf("package%d", i)] = fmt.Sprintf("%s%d", strings.Repeat("a", 140), i)
+	}
+	encoded := encodeBuildArgs(BuildArgs{Alias: longAliases}, false)
+	if len(encoded) <= base64.RawURLEncoding.EncodedLen(maxBuildArgBytes) {
+		t.Fatal("round-trip fixture does not exceed the direct query limit")
+	}
+	decoded, err := decodeBuildArgs("X-" + encoded)
+	if err != nil || !maps.Equal(decoded.Alias, longAliases) {
+		t.Fatalf("failed to round-trip canonical build args: %v", err)
+	}
+}
+
+func TestResolveConditionOrder(t *testing.T) {
+	conditions := npm.NewJSONObject(
+		[]string{"alpha", "beta"},
+		map[string]any{"alpha": "./alpha.js", "beta": "./beta.js"},
+	)
+	for _, test := range []struct {
+		order []string
+		want  string
+	}{
+		{[]string{"alpha", "beta"}, "./alpha.js"},
+		{[]string{"beta", "alpha"}, "./beta.js"},
+	} {
+		ctx := BuildContext{args: BuildArgs{Conditions: test.order}}
+		if entry := ctx.resolveConditionExportEntry(conditions, "module"); entry.main != test.want {
+			t.Fatalf("conditions %v resolved %q, want %q", test.order, entry.main, test.want)
+		}
+	}
+}
+
+func TestNormalizeBuildArgsCanonicalizesUnusedVariants(t *testing.T) {
+	const (
+		usedName            = "normalize-used-fixture"
+		replacementName     = "normalize-replacement-fixture"
+		implicitName        = "normalize-implicit-fixture"
+		dependencyAliasName = "normalize-dependency-alias-fixture"
+		aliasedName         = "normalize-aliased-fixture"
+	)
+	t.Cleanup(func() {
+		cacheStore.Range(func(key, _ any) bool {
+			s := key.(string)
+			for _, name := range []string{usedName, replacementName, implicitName, dependencyAliasName, aliasedName} {
+				if strings.HasPrefix(s, "npm:"+name+"@") || strings.HasPrefix(s, "404:"+name+"@") {
+					cacheStore.Delete(key)
+				}
+			}
+			return true
+		})
+	})
+	registry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		name, version := path.Split(strings.TrimPrefix(r.URL.Path, "/"))
+		name = strings.TrimSuffix(name, "/")
+		if version == "0.0.0-missing" {
+			http.NotFound(w, r)
+			return
+		}
+		resolved := map[string]string{
+			usedName:        "2.0.0",
+			replacementName: "1.2.3",
+			implicitName:    "2.0.0",
+			aliasedName:     "3.1.0",
+		}[name]
+		if resolved == "" || (version != "latest" && version != resolved) {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprintf(w, `{"name":%q,"version":%q}`, name, resolved)
+	}))
+	defer registry.Close()
+	reg := &NpmRegistry{NpmRegistryConfig: NpmRegistryConfig{Registry: registry.URL + "/"}}
+	reg.versionRouteSupported.Store(1)
+	npmrc := &NpmRC{globalRegistry: reg, scopedRegistries: map[string]*NpmRegistry{}}
+
+	wd := t.TempDir()
+	pkgDir := path.Join(wd, "node_modules", "fixture")
+	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path.Join(pkgDir, "package.json"), []byte(`{"name":"fixture","version":"1.0.0"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := BuildContext{
+		npmrc:   npmrc,
+		wd:      wd,
+		esmPath: EsmPath{PkgName: "fixture", PkgVersion: "1.0.0"},
+		args: BuildArgs{
+			Alias: map[string]string{"unused": "preact"},
+			Deps:  map[string]string{"unused": "1.0.0"},
+		},
+		target: "es2022",
+	}
+	rawPath := ctx.Path()
+	canonicalPath := (&BuildContext{
+		esmPath: ctx.esmPath,
+		target:  ctx.target,
+	}).Path()
+	if err := ctx.normalizeBuildArgs(); err != nil {
+		t.Fatal(err)
+	}
+	if len(ctx.args.Alias) != 0 || len(ctx.args.Deps) != 0 {
+		t.Fatalf("unused build arguments were not removed: %#v", ctx.args)
+	}
+	if ctx.Path() != canonicalPath || ctx.rawPath != rawPath {
+		t.Fatalf("build path was not canonicalized: raw=%q got=%q want=%q", rawPath, ctx.Path(), canonicalPath)
+	}
+
+	if err := os.WriteFile(path.Join(pkgDir, "package.json"), []byte(fmt.Sprintf(`{"name":"fixture","version":"1.0.0","dependencies":{%q:"^1.0.0"}}`, usedName)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	ctx = BuildContext{
+		npmrc:   npmrc,
+		wd:      wd,
+		esmPath: EsmPath{PkgName: "fixture", PkgVersion: "1.0.0"},
+		args: BuildArgs{
+			Alias: map[string]string{usedName: replacementName},
+			Deps:  map[string]string{usedName: "2.0.0"},
+		},
+		target: "es2022",
+	}
+	rawPath = ctx.Path()
+	if err := ctx.normalizeBuildArgs(); err != nil {
+		t.Fatal(err)
+	}
+	if ctx.args.Alias[usedName] != replacementName+"@1.2.3" || ctx.args.Deps[usedName] != "2.0.0" {
+		t.Fatalf("used build arguments were removed: %#v", ctx.args)
+	}
+	if ctx.Path() == rawPath || ctx.rawPath != rawPath {
+		t.Fatalf("meaningful build path was not canonicalized: raw=%q normalized=%q", rawPath, ctx.Path())
+	}
+
+	ctx = BuildContext{
+		npmrc:   npmrc,
+		wd:      wd,
+		esmPath: EsmPath{PkgName: "fixture", PkgVersion: "1.0.0", SubPath: implicitName},
+		args: BuildArgs{
+			Alias:    map[string]string{implicitName: replacementName},
+			Deps:     map[string]string{implicitName: "2.0.0"},
+			External: *set.NewReadOnly(implicitName),
+		},
+		target: "es2022",
+	}
+	rawPath = ctx.Path()
+	if err := ctx.normalizeBuildArgs(); err != nil {
+		t.Fatal(err)
+	}
+	if ctx.args.Alias[implicitName] != replacementName+"@1.2.3" || ctx.args.Deps[implicitName] != "2.0.0" || !ctx.args.External.Has(implicitName) {
+		t.Fatalf("subpath dependency arguments were removed: %#v", ctx.args)
+	}
+	if ctx.Path() == rawPath || ctx.rawPath != rawPath {
+		t.Fatalf("subpath dependency path was not canonicalized: raw=%q normalized=%q", rawPath, ctx.Path())
+	}
+
+	if err := os.WriteFile(path.Join(pkgDir, "package.json"), []byte(fmt.Sprintf(
+		`{"name":"fixture","version":"1.0.0","dependencies":{%q:"^1.0.0",%q:"npm:%s@3.1.0"}}`,
+		usedName,
+		dependencyAliasName,
+		aliasedName,
+	)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	ctx = BuildContext{
+		npmrc: npmrc,
+		wd:    wd,
+		pkgJson: &npm.PackageJSON{Dependencies: map[string]string{
+			usedName:            "^1.0.0",
+			dependencyAliasName: "npm:" + aliasedName + "@3.1.0",
+		}},
+		esmPath: EsmPath{PkgName: "fixture", PkgVersion: "1.0.0"},
+		args: BuildArgs{
+			Alias: map[string]string{usedName: dependencyAliasName + "/compat"},
+		},
+		target: "es2022",
+	}
+	if err := ctx.normalizeBuildArgs(); err != nil {
+		t.Fatal(err)
+	}
+	if ctx.args.Alias[usedName] != aliasedName+"@3.1.0/compat" {
+		t.Fatalf("npm alias selector was not canonicalized: %#v", ctx.args.Alias)
+	}
+
+	ctx = BuildContext{
+		npmrc:   npmrc,
+		wd:      wd,
+		esmPath: EsmPath{PkgName: "fixture", PkgVersion: "1.0.0"},
+		args:    BuildArgs{Deps: map[string]string{usedName: "0.0.0-missing"}},
+		target:  "es2022",
+	}
+	if err := ctx.normalizeBuildArgs(); err == nil {
+		t.Fatal("nonexistent dependency version was accepted")
+	}
+
+	ctx = BuildContext{
+		npmrc:   npmrc,
+		wd:      wd,
+		esmPath: EsmPath{PkgName: "fixture", PkgVersion: "1.0.0"},
+		args:    BuildArgs{Alias: map[string]string{usedName: replacementName + "@0.0.0-missing"}},
+		target:  "es2022",
+	}
+	if err := ctx.normalizeBuildArgs(); err == nil {
+		t.Fatal("nonexistent alias target version was accepted")
+	}
+}
+
+func TestTypeBuildPathIncludesArgs(t *testing.T) {
+	for _, subPath := range []string{"index.d.ts", "index.d.mts", "index.d.cts", "source.ts", "source.tsx"} {
+		plain := (&BuildContext{
+			esmPath: EsmPath{PkgName: "fixture", PkgVersion: "1.0.0", SubPath: subPath},
+			target:  "types",
+		}).Path()
+		withArgs := (&BuildContext{
+			esmPath: EsmPath{PkgName: "fixture", PkgVersion: "1.0.0", SubPath: subPath},
+			args:    BuildArgs{Conditions: []string{"browser"}},
+			target:  "types",
+		}).Path()
+		if plain == withArgs {
+			t.Errorf("%s build path does not include args", subPath)
+		}
 	}
 }

--- a/server/build_meta.go
+++ b/server/build_meta.go
@@ -149,6 +149,6 @@ func (storage *BuildMetaDB) Delete(key string) (err error) {
 }
 
 func normalizeMetaStoreKey(key string) string {
-	data := sha256.Sum256([]byte(key))
+	data := sha256.Sum256([]byte(buildCacheVersion + ":" + key))
 	return "meta/" + hex.EncodeToString(data[:])
 }

--- a/server/build_meta_test.go
+++ b/server/build_meta_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"reflect"
 	"testing"
 )
@@ -31,5 +33,13 @@ func TestEncodeBuildMeta(t *testing.T) {
 	metaEmpty := &BuildMeta{}
 	if !reflect.DeepEqual(meta3, metaEmpty) {
 		t.Fatalf("meta mismatch: %+v != %+v", meta3, metaEmpty)
+	}
+}
+
+func TestBuildMetaCacheVersion(t *testing.T) {
+	key := "/package@1.0.0/es2022/package.mjs"
+	legacy := sha256.Sum256([]byte(key))
+	if normalizeMetaStoreKey(key) == "meta/"+hex.EncodeToString(legacy[:]) {
+		t.Fatal("build metadata still reuses the legacy cache key")
 	}
 }

--- a/server/build_queue.go
+++ b/server/build_queue.go
@@ -13,6 +13,7 @@ import (
 type BuildQueue struct {
 	lock      sync.Mutex
 	tasks     map[string]*BuildTask
+	canonical map[string]*BuildTask
 	queue     map[*BuildTask]struct{}
 	pending   *list.List
 	chann     int
@@ -21,6 +22,8 @@ type BuildQueue struct {
 
 type BuildTask struct {
 	ctx       *BuildContext
+	key       string
+	canonical string
 	waitChans []chan BuildOutput
 	createdAt time.Time
 	startedAt time.Time
@@ -28,6 +31,7 @@ type BuildTask struct {
 
 type BuildOutput struct {
 	meta *BuildMeta
+	ctx  *BuildContext
 	err  error
 }
 
@@ -36,10 +40,11 @@ func NewBuildQueue(concurrency int) *BuildQueue {
 		concurrency = 1 // ensure at least 1 concurrent task
 	}
 	return &BuildQueue{
-		queue:   map[*BuildTask]struct{}{},
-		pending: list.New(),
-		tasks:   map[string]*BuildTask{},
-		chann:   concurrency,
+		queue:     map[*BuildTask]struct{}{},
+		pending:   list.New(),
+		tasks:     map[string]*BuildTask{},
+		canonical: map[string]*BuildTask{},
+		chann:     concurrency,
 	}
 }
 
@@ -50,7 +55,11 @@ func (q *BuildQueue) Add(ctx *BuildContext) chan BuildOutput {
 
 	ch := make(chan BuildOutput, 1)
 
-	task, ok := q.tasks[ctx.Path()]
+	key := ctx.Path()
+	task, ok := q.canonical[key]
+	if !ok {
+		task, ok = q.tasks[key]
+	}
 	if ok {
 		task.waitChans = append(task.waitChans, ch)
 		return ch
@@ -58,13 +67,14 @@ func (q *BuildQueue) Add(ctx *BuildContext) chan BuildOutput {
 
 	task = &BuildTask{
 		ctx:       ctx,
+		key:       key,
 		createdAt: time.Now(),
 		waitChans: []chan BuildOutput{ch},
 	}
 	ctx.status = "pending"
 
 	q.pending.PushBack(task)
-	q.tasks[ctx.Path()] = task
+	q.tasks[key] = task
 
 	q.startSchedulerLocked()
 
@@ -136,15 +146,13 @@ func (q *BuildQueue) run(task *BuildTask) {
 			task.ctx.logger.Errorf("build '%s' panicked: %v", task.ctx.Path(), r)
 		}
 
-		waitChans := task.waitChans
-
 		q.lock.Lock()
+		waitChans := task.waitChans
 		q.chann++
 		delete(q.queue, task)
-		delete(q.tasks, task.ctx.Path())
-		if task.ctx.rawPath != "" {
-			// the `Build` function may have changed the path
-			delete(q.tasks, task.ctx.rawPath)
+		q.deleteTaskLocked(task.key, task)
+		if task.canonical != "" && q.canonical[task.canonical] == task {
+			delete(q.canonical, task.canonical)
 		}
 		q.startSchedulerLocked()
 		q.lock.Unlock()
@@ -168,6 +176,9 @@ func (q *BuildQueue) run(task *BuildTask) {
 	buildCtx, cancel := context.WithTimeout(context.Background(), buildTimeout)
 	defer cancel()
 
+	task.ctx.onPathReady = func() bool {
+		return q.rekey(task)
+	}
 	meta, err := task.ctx.Build(buildCtx)
 	if errors.Is(err, context.DeadlineExceeded) {
 		err = fmt.Errorf("build timeout after %d seconds", buildTimeout/time.Second)
@@ -183,5 +194,28 @@ func (q *BuildQueue) run(task *BuildTask) {
 		task.ctx.status = "error"
 		task.ctx.logger.Errorf("build '%s': %v", task.ctx.Path(), err)
 	}
-	output = BuildOutput{meta: meta, err: err}
+	output = BuildOutput{meta: meta, ctx: task.ctx, err: err}
+}
+
+func (q *BuildQueue) deleteTaskLocked(key string, task *BuildTask) {
+	if key != "" && q.tasks[key] == task {
+		delete(q.tasks, key)
+	}
+}
+
+func (q *BuildQueue) rekey(task *BuildTask) bool {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	key := task.ctx.Path()
+	if current := q.canonical[key]; current != nil && current != task {
+		current.waitChans = append(current.waitChans, task.waitChans...)
+		task.waitChans = nil
+		q.deleteTaskLocked(task.key, task)
+		task.ctx.status = "joined"
+		return false
+	}
+	q.canonical[key] = task
+	task.canonical = key
+	return true
 }

--- a/server/build_queue_test.go
+++ b/server/build_queue_test.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/esm-dev/esm.sh/internal/storage"
+	"github.com/ije/gox/log"
+)
+
+func TestBuildQueueKeepsCanonicalTaskWhenRawTaskRekeys(t *testing.T) {
+	raw := &BuildTask{ctx: &BuildContext{path: "/canonical", rawPath: "/raw"}}
+	canonical := &BuildTask{ctx: &BuildContext{path: "/canonical"}}
+	q := &BuildQueue{tasks: map[string]*BuildTask{
+		"/raw":       raw,
+		"/canonical": canonical,
+	}}
+
+	q.deleteTaskLocked(raw.ctx.Path(), raw)
+	q.deleteTaskLocked(raw.ctx.rawPath, raw)
+
+	if q.tasks["/canonical"] != canonical {
+		t.Fatal("raw task cleanup removed the canonical task")
+	}
+	if _, ok := q.tasks["/raw"]; ok {
+		t.Fatal("raw task was not removed")
+	}
+}
+
+func TestBuildQueueJoinsCanonicalizedVariants(t *testing.T) {
+	first := &BuildTask{
+		ctx:       &BuildContext{path: "/canonical"},
+		key:       "/raw-a",
+		waitChans: []chan BuildOutput{make(chan BuildOutput, 1)},
+	}
+	second := &BuildTask{
+		ctx:       &BuildContext{path: "/canonical"},
+		key:       "/raw-b",
+		waitChans: []chan BuildOutput{make(chan BuildOutput, 1)},
+	}
+	q := &BuildQueue{
+		tasks: map[string]*BuildTask{
+			first.key:  first,
+			second.key: second,
+		},
+		canonical: map[string]*BuildTask{},
+	}
+
+	if !q.rekey(first) {
+		t.Fatal("first canonical task was not registered")
+	}
+	if q.rekey(second) {
+		t.Fatal("equivalent variant was not joined")
+	}
+	if len(first.waitChans) != 2 || len(second.waitChans) != 0 {
+		t.Fatal("variant waiters were not transferred")
+	}
+	if q.canonical["/canonical"] != first {
+		t.Fatal("canonical task ownership changed")
+	}
+	if _, ok := q.tasks[second.key]; ok {
+		t.Fatal("joined raw task remained addressable")
+	}
+}
+
+func TestBuildQueueReturnsExecutedContextToAllWaiters(t *testing.T) {
+	fs, err := storage.NewFSStorage(filepath.Join(t.TempDir(), "storage"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger, err := log.New("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	metaDB := NewBuildMetaDB(fs)
+	first := &BuildContext{
+		logger:  logger,
+		metaDB:  metaDB,
+		esmPath: EsmPath{PkgName: "queue-fixture", PkgVersion: "1.0.0"},
+		target:  "es2022",
+	}
+	second := &BuildContext{
+		logger:  logger,
+		metaDB:  metaDB,
+		esmPath: first.esmPath,
+		target:  first.target,
+	}
+	if err := metaDB.Put(first.Path(), encodeBuildMeta(&BuildMeta{})); err != nil {
+		t.Fatal(err)
+	}
+
+	q := NewBuildQueue(1)
+	q.chann = 0
+	firstOutput := q.Add(first)
+	secondOutput := q.Add(second)
+	q.lock.Lock()
+	q.chann = 1
+	q.startSchedulerLocked()
+	q.lock.Unlock()
+
+	for _, ch := range []chan BuildOutput{firstOutput, secondOutput} {
+		output := <-ch
+		if output.err != nil {
+			t.Fatal(output.err)
+		}
+		if output.ctx != first {
+			t.Fatal("waiter did not receive the executed build context")
+		}
+	}
+}

--- a/server/build_resolver.go
+++ b/server/build_resolver.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path"
 	"slices"
@@ -987,11 +988,12 @@ func (ctx *BuildContext) resolveExternalModule(specifier string, kind esbuild.Re
 	}
 	params := []string{}
 	if len(args.Alias) > 0 {
-		var alias []string
+		var alias sort.StringSlice
 		for k, v := range args.Alias {
 			alias = append(alias, fmt.Sprintf("%s:%s", k, v))
 		}
-		params = append(params, "alias="+strings.Join(alias, ","))
+		alias.Sort()
+		params = append(params, "alias="+url.QueryEscape(strings.Join(alias, ",")))
 	}
 	if len(args.Deps) > 0 {
 		var deps sort.StringSlice
@@ -999,7 +1001,7 @@ func (ctx *BuildContext) resolveExternalModule(specifier string, kind esbuild.Re
 			deps = append(deps, n+"@"+v)
 		}
 		deps.Sort()
-		params = append(params, "deps="+strings.Join(deps, ","))
+		params = append(params, "deps="+url.QueryEscape(strings.Join(deps, ",")))
 	}
 	if args.External.Len() > 0 {
 		external := make(sort.StringSlice, args.External.Len())
@@ -1007,13 +1009,10 @@ func (ctx *BuildContext) resolveExternalModule(specifier string, kind esbuild.Re
 			external[i] = e
 		}
 		external.Sort()
-		params = append(params, "external="+strings.Join(external, ","))
+		params = append(params, "external="+url.QueryEscape(strings.Join(external, ",")))
 	}
 	if len(args.Conditions) > 0 {
-		conditions := make(sort.StringSlice, len(args.Conditions))
-		copy(conditions, args.Conditions)
-		conditions.Sort()
-		params = append(params, "conditions="+strings.Join(conditions, ","))
+		params = append(params, "conditions="+url.QueryEscape(strings.Join(args.Conditions, ",")))
 	}
 	if dep.SubPath != "" && strings.HasSuffix(dep.SubPath, ".json") {
 		params = append(params, "module")
@@ -1128,7 +1127,7 @@ func (ctx *BuildContext) getImportPath(esm EsmPath, buildArgsPrefix string, exte
 }
 
 func (ctx *BuildContext) getSavePath() string {
-	return normalizeSavePath(path.Join("modules", ctx.Path()))
+	return normalizeSavePath(path.Join(buildStoragePrefix, ctx.Path()))
 }
 
 func (ctx *BuildContext) getBuildArgsPrefix(isDts bool) string {

--- a/server/build_test.go
+++ b/server/build_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -22,7 +23,10 @@ func TestBuildModuleJSONPathTraversal(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(wd, "secret.json"), []byte(`{"secret":true}`), 0644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(pkgDir, "data.json"), []byte(`{"safe":true}`), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(pkgDir, "invalid.json"), []byte(`{"safe":true};globalThis.PWNED=true`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "data.json"), []byte(`{"safe":"</script>"}`), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -60,6 +64,28 @@ func TestBuildModuleJSONPathTraversal(t *testing.T) {
 		esmPath: EsmPath{
 			PkgName:    pkgName,
 			PkgVersion: "1.0.0",
+			SubPath:    "invalid.json",
+		},
+		pkgJson: pkgJson,
+		path:    "invalid.mjs",
+	}
+	meta, _, err = ctx.buildModule(false)
+	if err == nil {
+		t.Fatal("expected invalid JSON to be rejected")
+	}
+	if meta != nil {
+		t.Fatal("expected no build metadata")
+	}
+	if _, err := fs.Stat(ctx.getSavePath()); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("expected no cached module, got %v", err)
+	}
+
+	ctx = &BuildContext{
+		storage: fs,
+		wd:      wd,
+		esmPath: EsmPath{
+			PkgName:    pkgName,
+			PkgVersion: "1.0.0",
 			SubPath:    "data.json",
 		},
 		pkgJson: pkgJson,
@@ -81,7 +107,31 @@ func TestBuildModuleJSONPathTraversal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(data) != `export default {"safe":true}` {
+	if string(data) != `export default {"safe":"\u003c/script\u003e"}` {
 		t.Fatalf("unexpected module output: %s", data)
+	}
+}
+
+func TestEncodeJSONModule(t *testing.T) {
+	js, err := encodeJSONModule([]byte("{\"value\":\"</script>\u2028\"}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(js) != `export default {"value":"\u003c/script\u003e\u2028"}` {
+		t.Fatalf("unexpected module output: %s", js)
+	}
+
+	if _, err := encodeJSONModule([]byte(`{"safe":true};globalThis.PWNED=true`)); err == nil {
+		t.Fatal("expected injected JavaScript to be rejected")
+	}
+}
+
+func TestBuildStorageVersion(t *testing.T) {
+	ctx := &BuildContext{path: "/package@1.0.0/es2022/package.mjs"}
+	if got := ctx.getSavePath(); got != "modules/v2/package@1.0.0/es2022/package.mjs" {
+		t.Fatalf("unexpected build storage path: %s", got)
+	}
+	if got := normalizeSavePath(path.Join(typesStoragePrefix, "/package@1.0.0/index.d.ts")); got != "types/v2/package@1.0.0/index.d.ts" {
+		t.Fatalf("unexpected types storage path: %s", got)
 	}
 }

--- a/server/consts.go
+++ b/server/consts.go
@@ -5,6 +5,9 @@ const (
 	maxAssetFileSize      = 50 * MB
 	maxPackageTarballSize = 256 * MB
 	lruCacheCapacity      = 10000
+	buildCacheVersion     = "v2"
+	buildStoragePrefix    = "modules/" + buildCacheVersion
+	typesStoragePrefix    = "types/" + buildCacheVersion
 )
 
 // asset file extensions

--- a/server/dts_transform.go
+++ b/server/dts_transform.go
@@ -41,7 +41,7 @@ func transformDTS(ctx *BuildContext, dts string, buildArgsPrefix string, marker 
 	}
 	marker.Add(dtsPath)
 
-	savePath := normalizeSavePath(path.Join("types", dtsPath))
+	savePath := normalizeSavePath(path.Join(typesStoragePrefix, dtsPath))
 	// check if the dts file has been transformed
 	_, err = ctx.storage.Stat(savePath)
 	if err == nil || err != storage.ErrNotFound {

--- a/server/embed/index.html
+++ b/server/embed/index.html
@@ -372,7 +372,7 @@
     hljs.registerLanguage("xml", xml);
 
     init("/md4w@0.2.7/js/md4w-small.wasm").then(() => {
-      const html = mdToHtml(README);
+      const html = mdToHtml(README.replaceAll("https://esm.sh", location.origin));
       document.querySelector("main").innerHTML = html;
 
       // scroll to hashHeading

--- a/server/legacy_router.go
+++ b/server/legacy_router.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,7 +12,6 @@ import (
 
 	"github.com/esm-dev/esm.sh/internal/npm"
 	"github.com/esm-dev/esm.sh/internal/storage"
-	"github.com/ije/esbuild-internal/xxhash"
 	"github.com/ije/gox/utils"
 	"github.com/ije/gox/valid"
 	"github.com/ije/rex"
@@ -152,7 +150,6 @@ func legacyESM(ctx *rex.Context, fs storage.Storage, buildVersionPrefix string) 
 				return rex.Status(500, err.Error())
 			}
 			var b strings.Builder
-			b.WriteString(getOrigin(ctx))
 			if buildVersionPrefix != "" {
 				b.WriteByte('/')
 				b.WriteString(buildVersionPrefix)
@@ -189,19 +186,16 @@ func legacyESM(ctx *rex.Context, fs storage.Storage, buildVersionPrefix string) 
 				ctx.SetHeader("Content-Type", ctJavaScript)
 			case ".ts", ".mts":
 				ctx.SetHeader("Content-Type", ctTypeScript)
-				// resolve hostname in typescript definition files if the origin is not "https://esm.sh"
 				if endsWith(pathname, ".d.ts", ".d.mts") {
-					origin := getOrigin(ctx)
-					if origin != "https://esm.sh" {
-						defer f.Close()
-						data, err := io.ReadAll(f)
-						if err != nil {
-							return rex.Status(500, "Failed to read data from storage")
-						}
-						data = bytes.ReplaceAll(data, []byte("https://esm.sh/v"), []byte(origin+"/v"))
-						data = bytes.ReplaceAll(data, []byte("https://legacy.esm.sh/v"), []byte(origin+"/v"))
-						return data
+					defer f.Close()
+					data, err := io.ReadAll(f)
+					if err != nil {
+						return rex.Status(500, "Failed to read data from storage")
 					}
+					data = bytes.ReplaceAll(data, []byte("https://esm.sh/v"), []byte("/v"))
+					data = bytes.ReplaceAll(data, []byte("https://legacy.esm.sh/v"), []byte("/v"))
+					ctx.SetHeader("Cache-Control", ccImmutable)
+					return data
 				}
 			case ".map":
 				ctx.SetHeader("Content-Type", ctJSON)
@@ -222,9 +216,7 @@ func legacyESM(ctx *rex.Context, fs storage.Storage, buildVersionPrefix string) 
 				varyUA = true
 				savePath += "." + getBuildTargetByUA(ctx.UserAgent())
 			}
-			h := xxhash.New()
-			h.Write([]byte(query))
-			savePath += "." + base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+			savePath += "." + sha256Base64(query)
 		}
 		savePath += ".meta"
 		f, _, e := fs.Get(savePath)
@@ -244,7 +236,7 @@ func legacyESM(ctx *rex.Context, fs storage.Storage, buildVersionPrefix string) 
 					ctx.SetHeader("X-ESM-Id", ret.EsmId)
 				}
 				if ret.Dts != "" {
-					ctx.SetHeader("X-TypeScript-Types", getOrigin(ctx)+ret.Dts)
+					ctx.SetHeader("X-TypeScript-Types", ret.Dts)
 				}
 				return ret.Code
 			}
@@ -253,13 +245,12 @@ func legacyESM(ctx *rex.Context, fs storage.Storage, buildVersionPrefix string) 
 
 	// strip leading `/stable/*` and `/v<build-version>/*`
 	if buildVersionPrefix != "" {
-		origin := getOrigin(ctx)
 		if strings.HasPrefix(pathname, "/node_") && strings.HasSuffix(pathname, ".js") {
 			pathname = "/node/" + strings.TrimSuffix(strings.TrimPrefix(pathname, "/node_"), ".js") + ".mjs"
 		} else if pathname == "/node.ns.d.ts" {
 			return rex.Status(404, "Not Found")
 		}
-		return redirect(ctx, fmt.Sprintf("%s%s%s", origin, pathname, query), true)
+		return redirect(ctx, pathname+query, true)
 	}
 
 	return rex.Next()

--- a/server/npmrc.go
+++ b/server/npmrc.go
@@ -322,6 +322,9 @@ func (npmrc *NpmRC) installPackageContext(ctx context.Context, pkg npm.Package) 
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	if pkg.PkgPrNew && (!npm.ValidatePkgPrNewName(pkg.Name) || !npm.ValidatePkgPrNewVersion(pkg.Version)) {
+		return nil, errors.New("invalid pkg.pr.new package")
+	}
 	installDir := filepath.Join(npmrc.StoreDir(), pkg.String())
 	packageJsonPath := filepath.Join(installDir, "node_modules", pkg.Name, "package.json")
 

--- a/server/npmrc_test.go
+++ b/server/npmrc_test.go
@@ -14,7 +14,20 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/esm-dev/esm.sh/internal/npm"
 )
+
+func TestInstallPackageRejectsInvalidPkgPrNewName(t *testing.T) {
+	npmrc := &NpmRC{}
+	if _, err := npmrc.installPackageContext(context.Background(), npm.Package{
+		PkgPrNew: true,
+		Name:     "owner/../package",
+		Version:  "a832a55",
+	}); err == nil {
+		t.Fatal("expected invalid pkg.pr.new package name to be rejected")
+	}
+}
 
 func TestSameURLOrigin(t *testing.T) {
 	registryUrl, _ := url.Parse("https://registry.example/package")

--- a/server/path.go
+++ b/server/path.go
@@ -64,12 +64,12 @@ func parseEsmPath(npmrc *NpmRC, pathname string) (esm EsmPath, extraQuery string
 			pathname = pathname[12:]
 		}
 		pkgName, rest := utils.SplitByLastByte(pathname, '@')
-		if rest == "" {
+		if rest == "" || !npm.ValidatePkgPrNewName(pkgName) {
 			err = errors.New("invalid path")
 			return
 		}
 		version, subPath := utils.SplitByFirstByte(rest, '/')
-		if version == "" || !npm.Versioning.Match(version) {
+		if !npm.ValidatePkgPrNewVersion(version) {
 			err = errors.New("invalid path")
 			return
 		}

--- a/server/path_test.go
+++ b/server/path_test.go
@@ -2,8 +2,40 @@ package server
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 )
+
+func TestParsePrPath(t *testing.T) {
+	for _, pathname := range []string{
+		"/pr/tinybench@a832a55",
+		"/pr/sveltejs/svelte@a832a55",
+		"/pr/tinylibs/tinybench/tinybench@a832a55",
+		"/pr/owner/repo/@scope/package@a832a55",
+	} {
+		if _, _, _, _, _, err := parseEsmPath(nil, pathname); err != nil {
+			t.Errorf("expected %q to be valid: %v", pathname, err)
+		}
+	}
+
+	for _, pathname := range []string{
+		"/pr/@a832a55",
+		"/pr/.@a832a55",
+		"/pr/..@a832a55",
+		"/pr/owner/../package@a832a55",
+		"/pr/owner/repo/package/extra/name@a832a55",
+		"/pr/owner/repo/package%name@a832a55",
+	} {
+		if _, _, _, _, _, err := parseEsmPath(nil, pathname); err == nil {
+			t.Errorf("expected %q to be rejected", pathname)
+		}
+	}
+
+	pathname := httptest.NewRequest(http.MethodGet, "/pr/owner/%2e%2e/package@a832a55", nil).URL.Path
+	if _, _, _, _, _, err := parseEsmPath(nil, pathname); err == nil {
+		t.Errorf("expected percent-encoded traversal path %q to be rejected", pathname)
+	}
+}
 
 func TestPrCommitFromHeader(t *testing.T) {
 	tests := []struct {

--- a/server/router.go
+++ b/server/router.go
@@ -24,7 +24,6 @@ import (
 	"github.com/esm-dev/esm.sh/internal/mime"
 	"github.com/esm-dev/esm.sh/internal/storage"
 	esbuild "github.com/ije/esbuild-internal/api"
-	"github.com/ije/esbuild-internal/xxhash"
 	"github.com/ije/gox/log"
 	"github.com/ije/gox/set"
 	"github.com/ije/gox/utils"
@@ -253,7 +252,6 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 				}
 				readme = bytes.ReplaceAll(readme, []byte("./server/embed/"), []byte("/embed/"))
 				readme = bytes.ReplaceAll(readme, []byte("./HOSTING.md"), []byte("https://github.com/esm-dev/esm.sh/blob/main/HOSTING.md"))
-				readme = bytes.ReplaceAll(readme, []byte("https://esm.sh"), []byte(getOrigin(ctx)))
 				indexHTML, err = embedFS.ReadFile("embed/index.html")
 				if err != nil {
 					err = errors.New("failed to read index.html: " + err.Error())
@@ -527,8 +525,6 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 			return rex.Status(403, "forbidden")
 		}
 
-		origin := getOrigin(ctx)
-
 		registryPrefix := ""
 		if esmPath.GhPrefix {
 			registryPrefix = "/gh"
@@ -553,12 +549,12 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 			} else if !endsWith(types, ".d.ts", ".d.mts", ".d.cts") {
 				types += ".d.ts"
 			}
-			return redirect(ctx, fmt.Sprintf("%s/%s@%s%s", origin, info.Name, info.Version, utils.NormalizePathname(types)), isExactVersion)
+			return redirect(ctx, fmt.Sprintf("/%s@%s%s", info.Name, info.Version, utils.NormalizePathname(types)), isExactVersion)
 		}
 
 		// redirect to the main css path for CSS packages
 		if css := cssPackages[esmPath.PkgName]; css != "" && esmPath.SubPath == "" {
-			url := fmt.Sprintf("%s/%s/%s", origin, esmPath.PackageId(), css)
+			url := fmt.Sprintf("/%s/%s", esmPath.PackageId(), css)
 			return redirect(ctx, url, isExactVersion)
 		}
 
@@ -688,7 +684,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 					query = "?" + rawQuery
 				}
 				ctx.SetHeader("Cache-Control", fmt.Sprintf("public, max-age=%d", config.NpmQueryCacheTTL))
-				return redirect(ctx, fmt.Sprintf("%s/%s%s%s", origin, pkgName, subPath, query), false)
+				return redirect(ctx, fmt.Sprintf("/%s%s%s", pkgName, subPath, query), false)
 			}
 			if pathKind != EsmEntry {
 				pkgName := esmPath.PkgName
@@ -719,7 +715,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 					query = "?" + rawQuery
 				}
 				ctx.SetHeader("Cache-Control", fmt.Sprintf("public, max-age=%d", config.NpmQueryCacheTTL))
-				return redirect(ctx, fmt.Sprintf("%s%s/%s@%s%s%s", origin, registryPrefix, pkgName, pkgVersion, subPath, query), false)
+				return redirect(ctx, fmt.Sprintf("%s/%s@%s%s%s", registryPrefix, pkgName, pkgVersion, subPath, query), false)
 			}
 		}
 
@@ -763,7 +759,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 				ctx.SetHeader("Cache-Control", ccImmutable)
 				return rex.Status(404, "File not found")
 			}
-			url := fmt.Sprintf("%s%s/%s@%s/%s", origin, registryPrefix, esmPath.PkgName, esmPath.PkgVersion, file)
+			url := fmt.Sprintf("%s/%s@%s/%s", registryPrefix, esmPath.PkgName, esmPath.PkgVersion, file)
 			return redirect(ctx, url, true)
 		}
 
@@ -771,11 +767,10 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 		if isExactVersion {
 			// return wasm file as an es6 module when `?module` query is present (requires `top-level-await` support)
 			if pathKind == RawFile && strings.HasSuffix(esmPath.SubPath, ".wasm") && query.Has("module") {
-				wasmUrl := origin + pathname
 				buf := bytes.NewBufferString("/* esm.sh - wasm module */\n")
-				buf.WriteString("const data = await fetch(")
-				buf.WriteString(strings.TrimSpace(string(utils.MustEncodeJSON(wasmUrl))))
-				buf.WriteString(").then(r => r.arrayBuffer());\n")
+				buf.WriteString("const data = await fetch(new URL(")
+				buf.WriteString(strings.TrimSpace(string(utils.MustEncodeJSON(pathname))))
+				buf.WriteString(", import.meta.url)).then(r => r.arrayBuffer());\n")
 				buf.WriteString("export default new WebAssembly.Module(data);")
 				ctx.SetHeader("Content-Type", ctJavaScript)
 				ctx.SetHeader("Content-Length", fmt.Sprintf("%d", buf.Len()))
@@ -827,7 +822,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 						query = "?" + rawQuery
 					}
 					// redirect to the 'main' JS file
-					return redirect(ctx, fmt.Sprintf("%s/%s%s%s", origin, esmPath.PackageId(), utils.NormalizePathname(entry.main), query), true)
+					return redirect(ctx, fmt.Sprintf("/%s%s%s", esmPath.PackageId(), utils.NormalizePathname(entry.main), query), true)
 				}
 
 				filename := path.Join(npmrc.StoreDir(), esmPath.PackageId(), "node_modules", esmPath.PkgName, esmPath.SubPath)
@@ -858,7 +853,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 								query = "?" + rawQuery
 							}
 							// redirect to the resolved path
-							return redirect(ctx, fmt.Sprintf("%s/%s%s%s", origin, esmPath.PackageId(), utils.NormalizePathname(entry.main), query), true)
+							return redirect(ctx, fmt.Sprintf("/%s%s%s", esmPath.PackageId(), utils.NormalizePathname(entry.main), query), true)
 						}
 						ctx.SetHeader("Cache-Control", ccImmutable)
 						return rex.Status(404, "File Not Found")
@@ -904,22 +899,32 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 					if err != nil {
 						return rex.Status(500, err.Error())
 					}
+					js, err := encodeJSONModule(jsonData)
+					if err != nil {
+						return rex.Status(500, err.Error())
+					}
 					ctx.SetHeader("Content-Type", ctJavaScript)
-					return concatBytes([]byte("export default "), jsonData)
+					return js
 				}
 				return content // auto closed
 			}
 
+			// Direct declaration query variants are keyed after parsing below.
+			dtsQueryVariant := pathKind == EsmDts &&
+				(query.Has("path") || (xArgs == nil &&
+					(query.Has("alias") || query.Has("deps") || query.Has("external") ||
+						query.Has("conditions"))))
+
 			// serve build/dts files
-			if pathKind == EsmBuild || pathKind == EsmSourceMap || pathKind == EsmDts {
+			if (pathKind == EsmBuild || pathKind == EsmSourceMap || pathKind == EsmDts) && !dtsQueryVariant {
 				var savePath string
 				if asteriskPrefix {
 					pathname = "/*" + pathname[1:]
 				}
 				if pathKind == EsmDts {
-					savePath = path.Join("types", pathname)
+					savePath = path.Join(typesStoragePrefix, pathname)
 				} else {
-					savePath = path.Join("modules", pathname)
+					savePath = path.Join(buildStoragePrefix, pathname)
 				}
 				savePath = normalizeSavePath(savePath)
 				f, stat, err := esmStorage.Get(savePath)
@@ -957,21 +962,15 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 						sort.Strings(exports)
 						if query.Has("worker") {
 							defer f.Close()
-							moduleUrl := origin + pathname
+							modulePath := pathname
 							if len(exports) > 0 {
-								moduleUrl += "?exports=" + strings.Join(exports, ",")
+								modulePath += "?exports=" + strings.Join(exports, ",")
 							}
-							return fmt.Sprintf(
-								`export default function workerFactory(injectOrOptions) { const options = typeof injectOrOptions === "string" ? { inject: injectOrOptions }: injectOrOptions ?? {}; const { inject, name = "%s" } = options; const blob = new Blob(['import * as $module from "%s";', inject].filter(Boolean), { type: "application/javascript" }); return new Worker(URL.createObjectURL(blob), { type: "module", name })}`,
-								moduleUrl,
-								moduleUrl,
-							)
+							return renderWorkerFactory(modulePath)
 						}
 						if len(exports) > 0 {
 							defer f.Close()
-							xxh := xxhash.New()
-							xxh.Write([]byte(strings.Join(exports, ",")))
-							savePath = strings.TrimSuffix(savePath, ".mjs") + "_" + base64.RawURLEncoding.EncodeToString(xxh.Sum(nil)) + ".mjs"
+							savePath = treeShakeSavePath(savePath, exports)
 							f2, stat, err := esmStorage.Get(savePath)
 							if err == nil {
 								ctx.SetHeader("Content-Length", fmt.Sprintf("%d", stat.Size()))
@@ -1008,7 +1007,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 						if err != nil {
 							return rex.Status(500, err.Error())
 						}
-						return bytes.ReplaceAll(buffer, []byte("{ESM_CDN_ORIGIN}"), []byte(origin))
+						return bytes.ReplaceAll(buffer, []byte("{ESM_CDN_ORIGIN}"), nil)
 					}
 					ctx.SetHeader("Content-Length", fmt.Sprintf("%d", stat.Size()))
 					return f // auto closed
@@ -1058,70 +1057,62 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 			if targetFromUA {
 				appendVaryHeader(ctx.W.Header(), "User-Agent")
 			}
-			return redirect(ctx, fmt.Sprintf("%s%s/%s@%s%s%s", origin, registryPrefix, pkgName, pkgVersion, subPath, qs), false)
+			return redirect(ctx, fmt.Sprintf("%s/%s@%s%s%s", registryPrefix, pkgName, pkgVersion, subPath, qs), false)
 		}
 
 		// check `?alias` query
 		alias := map[string]string{}
-		if query.Has("alias") {
-			for p := range strings.SplitSeq(query.Get("alias"), ",") {
-				p = strings.TrimSpace(p)
-				if p != "" {
-					name, to := utils.SplitByFirstByte(p, ':')
-					name = strings.TrimSpace(name)
-					to = strings.TrimSpace(to)
-					if name != "" && to != "" && name != esmPath.PkgName {
-						alias[name] = to
-					}
-				}
+		if xArgs == nil && query.Has("alias") {
+			alias, err = parseAliasArg(query.Get("alias"), maxBuildArgBytes)
+			if err != nil {
+				ctx.SetHeader("Cache-Control", ccImmutable)
+				return rex.Status(400, "Invalid alias query: "+err.Error())
 			}
+			delete(alias, esmPath.PkgName)
 		}
 
 		// check `?deps` query
 		deps := map[string]string{}
-		if query.Has("deps") {
-			for v := range strings.SplitSeq(query.Get("deps"), ",") {
-				v = strings.TrimSpace(v)
-				if v != "" {
-					esm, _, _, _, _, err := parseEsmPath(npmrc, v)
-					if err != nil {
-						ctx.SetHeader("Cache-Control", ccImmutable)
-						return rex.Status(400, fmt.Sprintf("Invalid deps query: %v not found", v))
-					}
-					if esm.PkgName != esmPath.PkgName {
-						deps[esm.PkgName] = esm.PkgVersion
-					}
+		if xArgs == nil && query.Has("deps") {
+			rawDeps, err := parseDepsArg(query.Get("deps"), maxBuildArgBytes)
+			if err != nil {
+				ctx.SetHeader("Cache-Control", ccImmutable)
+				return rex.Status(400, "Invalid deps query: "+err.Error())
+			}
+			for name, version := range rawDeps {
+				specifier := name
+				if version != "" {
+					specifier += "@" + version
+				}
+				esm, _, _, _, _, err := parseEsmPath(npmrc, specifier)
+				if err != nil {
+					ctx.SetHeader("Cache-Control", ccImmutable)
+					return rex.Status(400, fmt.Sprintf("Invalid deps query: %s not found", specifier))
+				}
+				if esm.PkgName != esmPath.PkgName {
+					deps[esm.PkgName] = esm.PkgVersion
 				}
 			}
 		}
 
 		// check `?conditions` query
 		var conditions []string
-		conditionsSet := set.New[string]()
-		if query.Has("conditions") {
-			for p := range strings.SplitSeq(query.Get("conditions"), ",") {
-				p = strings.TrimSpace(p)
-				if p != "" && !strings.ContainsRune(p, ' ') && !conditionsSet.Has(p) {
-					conditionsSet.Add(p)
-					conditions = append(conditions, p)
-				}
+		if xArgs == nil && query.Has("conditions") {
+			conditions, err = parseConditionsArg(query.Get("conditions"))
+			if err != nil {
+				ctx.SetHeader("Cache-Control", ccImmutable)
+				return rex.Status(400, "Invalid conditions query: "+err.Error())
 			}
 		}
 
 		// check `?external` query
 		external := set.New[string]()
 		externalAll := asteriskPrefix
-		if !asteriskPrefix && query.Has("external") {
-			for p := range strings.SplitSeq(query.Get("external"), ",") {
-				p = strings.TrimSpace(p)
-				if p == "*" {
-					external.Reset()
-					externalAll = true
-					break
-				}
-				if p != "" {
-					external.Add(p)
-				}
+		if xArgs == nil && !asteriskPrefix && query.Has("external") {
+			external, externalAll, err = parseExternalArg(query.Get("external"))
+			if err != nil {
+				ctx.SetHeader("Cache-Control", ccImmutable)
+				return rex.Status(400, "Invalid external query: "+err.Error())
 			}
 		}
 
@@ -1145,11 +1136,12 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 				if a := encodeBuildArgs(buildArgs, true); a != "" {
 					args = "X-" + a
 				}
-				savePath := normalizeSavePath(path.Join(fmt.Sprintf(
-					"types/%s/%s",
+				savePath := normalizeSavePath(path.Join(
+					typesStoragePrefix,
 					esmPath.PackageId(),
 					args,
-				), esmPath.SubPath))
+					esmPath.SubPath,
+				))
 				content, stat, err = esmStorage.Get(savePath)
 				return
 			}
@@ -1182,6 +1174,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 						}
 						return rex.Status(500, "Failed to build types: "+output.err.Error())
 					}
+					buildArgs = output.ctx.args
 				case <-time.After(time.Duration(config.BuildWaitTime) * time.Second):
 					ctx.SetHeader("Cache-Control", ccMustRevalidate)
 					return rex.Status(http.StatusRequestTimeout, "timeout, the types is waiting to be built, please try refreshing the page.")
@@ -1206,7 +1199,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 			}
 			ctx.SetHeader("Content-Type", ctTypeScript)
 			ctx.SetHeader("Cache-Control", ccImmutable)
-			return bytes.ReplaceAll(buffer, []byte("{ESM_CDN_ORIGIN}"), []byte(origin))
+			return bytes.ReplaceAll(buffer, []byte("{ESM_CDN_ORIGIN}"), nil)
 		}
 
 		if xArgs == nil {
@@ -1285,6 +1278,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 					return rex.Status(500, msg)
 				}
 				buildMeta = output.meta
+				build = output.ctx
 			case <-time.After(time.Duration(config.BuildWaitTime) * time.Second):
 				ctx.SetHeader("Cache-Control", ccMustRevalidate)
 				return rex.Status(http.StatusRequestTimeout, "timeout, the module is waiting to be built, please try refreshing the page.")
@@ -1292,14 +1286,13 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 		}
 
 		if buildMeta.CSSEntry != "" {
-			url := getCSSEntryRedirectURL(origin, esmPath, buildMeta.CSSEntry)
+			url := getCSSEntryRedirectURL(esmPath, buildMeta.CSSEntry)
 			return redirect(ctx, url, isExactVersion)
 		}
 
 		// redirect to `*.d.ts` file
 		if buildMeta.TypesOnly {
-			dtsUrl := origin + buildMeta.Dts
-			ctx.SetHeader("X-TypeScript-Types", dtsUrl)
+			ctx.SetHeader("X-TypeScript-Types", buildMeta.Dts)
 			ctx.SetHeader("Content-Type", ctJavaScript)
 			ctx.SetHeader("Cache-Control", ccImmutable)
 			if ctx.R.Method == http.MethodHead {
@@ -1318,7 +1311,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 				}
 				return rex.Status(404, "Package CSS not found")
 			}
-			url := origin + strings.TrimSuffix(build.Path(), ".mjs") + ".css"
+			url := strings.TrimSuffix(build.Path(), ".mjs") + ".css"
 			return redirect(ctx, url, isExactVersion)
 		}
 
@@ -1465,25 +1458,19 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 				ctx.SetHeader("Content-Type", ctJavaScript)
 				if query.Has("worker") {
 					defer f.Close()
-					moduleUrl := origin + build.Path()
+					modulePath := build.Path()
 					if !buildMeta.CJS && len(exports) > 0 {
-						moduleUrl += "?exports=" + strings.Join(exports, ",")
+						modulePath += "?exports=" + strings.Join(exports, ",")
 					}
-					return fmt.Sprintf(
-						`export default function workerFactory(injectOrOptions) { const options = typeof injectOrOptions === "string" ? { inject: injectOrOptions }: injectOrOptions ?? {}; const { inject, name = "%s" } = options; const blob = new Blob(['import * as $module from "%s";', inject].filter(Boolean), { type: "application/javascript" }); return new Worker(URL.createObjectURL(blob), { type: "module", name })}`,
-						moduleUrl,
-						moduleUrl,
-					)
+					return renderWorkerFactory(modulePath)
 				}
 				if noDts := query.Has("no-dts") || query.Has("no-check"); !noDts && buildMeta.Dts != "" {
-					ctx.SetHeader("X-TypeScript-Types", origin+buildMeta.Dts)
+					ctx.SetHeader("X-TypeScript-Types", buildMeta.Dts)
 					ctx.SetHeader("Access-Control-Expose-Headers", "X-TypeScript-Types")
 				}
 				if !buildMeta.CJS && len(exports) > 0 {
 					defer f.Close()
-					xxh := xxhash.New()
-					xxh.Write([]byte(strings.Join(exports, ",")))
-					savePath = strings.TrimSuffix(savePath, ".mjs") + "_" + base64.RawURLEncoding.EncodeToString(xxh.Sum(nil)) + ".mjs"
+					savePath = treeShakeSavePath(savePath, exports)
 					f2, stat, err := esmStorage.Get(savePath)
 					if err == nil {
 						ctx.SetHeader("Content-Length", fmt.Sprintf("%d", stat.Size()))
@@ -1514,15 +1501,11 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 		fmt.Fprintf(buf, "/* esm.sh - %s */\n", esmPath.String())
 
 		if query.Has("worker") {
-			moduleUrl := origin + build.Path()
+			modulePath := build.Path()
 			if !buildMeta.CJS && len(exports) > 0 {
-				moduleUrl += "?exports=" + strings.Join(exports, ",")
+				modulePath += "?exports=" + strings.Join(exports, ",")
 			}
-			fmt.Fprintf(buf,
-				`export default function workerFactory(injectOrOptions) { const options = typeof injectOrOptions === "string" ? { inject: injectOrOptions }: injectOrOptions ?? {}; const { inject, name = "%s" } = options; const blob = new Blob(['import * as $module from "%s";', inject].filter(Boolean), { type: "application/javascript" }); return new Worker(URL.createObjectURL(blob), { type: "module", name })}`,
-				moduleUrl,
-				moduleUrl,
-			)
+			buf.WriteString(renderWorkerFactory(modulePath))
 		} else {
 			if len(buildMeta.Imports) > 0 && !query.Has("exports") {
 				for _, dep := range buildMeta.Imports {
@@ -1543,7 +1526,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 			}
 			ctx.SetHeader("X-ESM-Path", esmPath)
 			if noDts := query.Has("no-dts") || query.Has("no-check"); !noDts && buildMeta.Dts != "" {
-				ctx.SetHeader("X-TypeScript-Types", origin+buildMeta.Dts)
+				ctx.SetHeader("X-TypeScript-Types", buildMeta.Dts)
 				ctx.SetHeader("Access-Control-Expose-Headers", "X-ESM-Path, X-TypeScript-Types")
 			} else {
 				ctx.SetHeader("Access-Control-Expose-Headers", "X-ESM-Path")
@@ -1564,22 +1547,6 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 		}
 		return buf.Bytes()
 	}
-}
-
-func getOrigin(ctx *rex.Context) string {
-	origin := ctx.R.Header.Get("X-Real-Origin")
-	if origin != "" {
-		return origin
-	}
-	proto := "http:"
-	if cfVisitor := ctx.R.Header.Get("CF-Visitor"); cfVisitor != "" {
-		if strings.Contains(cfVisitor, "\"https\"") {
-			proto = "https:"
-		}
-	} else if ctx.R.TLS != nil {
-		proto = "https:"
-	}
-	return proto + "//" + ctx.R.Host
 }
 
 func redirect(ctx *rex.Context, url string, isMovedPermanently bool) any {
@@ -1606,6 +1573,13 @@ func errorJS(ctx *rex.Context, message string) any {
 	return buf.Bytes()
 }
 
-func getCSSEntryRedirectURL(origin string, esmPath EsmPath, cssEntry string) string {
-	return origin + "/" + esmPath.PackageId() + utils.NormalizePathname(cssEntry)
+func renderWorkerFactory(modulePath string) string {
+	return fmt.Sprintf(
+		`export default function workerFactory(injectOrOptions) { const moduleUrl = new URL(%s, import.meta.url).href; const options = typeof injectOrOptions === "string" ? { inject: injectOrOptions }: injectOrOptions ?? {}; const { inject, name = moduleUrl } = options; const blob = new Blob(["import * as $module from " + JSON.stringify(moduleUrl) + ";", inject].filter(Boolean), { type: "application/javascript" }); return new Worker(URL.createObjectURL(blob), { type: "module", name })}`,
+		strings.TrimSpace(string(utils.MustEncodeJSON(modulePath))),
+	)
+}
+
+func getCSSEntryRedirectURL(esmPath EsmPath, cssEntry string) string {
+	return "/" + esmPath.PackageId() + utils.NormalizePathname(cssEntry)
 }

--- a/server/router_test.go
+++ b/server/router_test.go
@@ -1,11 +1,33 @@
 package server
 
 import (
+	"encoding/base64"
+	"strings"
 	"testing"
+
+	"github.com/ije/gox/utils"
 )
 
+func TestTreeShakeSavePath(t *testing.T) {
+	savePath := "modules/react.mjs"
+	a := treeShakeSavePath(savePath, []string{"default", "useState"})
+	if a != treeShakeSavePath(savePath, []string{"default", "useState"}) {
+		t.Fatal("expected deterministic tree-shake path")
+	}
+	if a == treeShakeSavePath(savePath, []string{"default", "useEffect"}) {
+		t.Fatal("expected distinct export sets to use distinct paths")
+	}
+	digest := strings.TrimSuffix(strings.TrimPrefix(a, "modules/react_"), ".mjs")
+	decoded, err := base64.RawURLEncoding.DecodeString(digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded) != 32 {
+		t.Fatalf("expected SHA-256 digest, got %d bytes", len(decoded))
+	}
+}
+
 func TestCSSEntryRedirectURL(t *testing.T) {
-	origin := "https://esm.sh"
 	esmPath := EsmPath{
 		PkgName:    "@material/web",
 		PkgVersion: "2.4.2-nightly.95dd57c.0",
@@ -17,19 +39,34 @@ func TestCSSEntryRedirectURL(t *testing.T) {
 	}{
 		{
 			cssEntry: "./labs/gb/components/ripple/ripple.css",
-			expected: "https://esm.sh/@material/web@2.4.2-nightly.95dd57c.0/labs/gb/components/ripple/ripple.css",
+			expected: "/@material/web@2.4.2-nightly.95dd57c.0/labs/gb/components/ripple/ripple.css",
 		},
 		{
 			cssEntry: "labs/gb/components/ripple/ripple.css",
-			expected: "https://esm.sh/@material/web@2.4.2-nightly.95dd57c.0/labs/gb/components/ripple/ripple.css",
+			expected: "/@material/web@2.4.2-nightly.95dd57c.0/labs/gb/components/ripple/ripple.css",
 		},
 	}
 
 	for _, test := range tests {
-		// Calling the actual helper function from router.go
-		url := getCSSEntryRedirectURL(origin, esmPath, test.cssEntry)
+		url := getCSSEntryRedirectURL(esmPath, test.cssEntry)
 		if url != test.expected {
 			t.Errorf("For CSSEntry %q, expected %q, but got %q", test.cssEntry, test.expected, url)
 		}
+	}
+}
+
+func TestRenderWorkerFactoryEscapesModulePath(t *testing.T) {
+	modulePath := "/mod\" } = options; globalThis.PWNED = true; const { z = \"\n\u2028"
+	code := renderWorkerFactory(modulePath)
+	encodedPath := strings.TrimSpace(string(utils.MustEncodeJSON(modulePath)))
+
+	if !strings.Contains(code, "new URL("+encodedPath+", import.meta.url)") {
+		t.Fatalf("worker module path is not JSON-encoded: %s", code)
+	}
+	if strings.Contains(code, modulePath) || strings.ContainsRune(code, '\u2028') {
+		t.Fatalf("worker module path is interpolated verbatim: %s", code)
+	}
+	if !strings.Contains(code, `JSON.stringify(moduleUrl)`) {
+		t.Fatalf("worker import specifier is not encoded at runtime: %s", code)
 	}
 }

--- a/server/utils.go
+++ b/server/utils.go
@@ -1,13 +1,18 @@
 package server
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/ije/gox/utils"
 	"github.com/ije/gox/valid"
 )
 
@@ -51,6 +56,25 @@ func isNodeBuiltinSpecifier(specifier string) bool {
 // isJsonModuleSpecifier returns true if the specifier is a json module.
 func isJsonModuleSpecifier(specifier string) bool {
 	return strings.HasSuffix(specifier, ".json")
+}
+
+func encodeJSONModule(data []byte) ([]byte, error) {
+	if !json.Valid(data) {
+		return nil, errors.New("invalid json")
+	}
+	return concatBytes(
+		[]byte("export default "),
+		bytes.TrimSuffix(utils.MustEncodeJSON(json.RawMessage(data)), []byte("\n")),
+	), nil
+}
+
+func treeShakeSavePath(savePath string, exports []string) string {
+	return strings.TrimSuffix(savePath, ".mjs") + "_" + sha256Base64(strings.Join(exports, ",")) + ".mjs"
+}
+
+func sha256Base64(value string) string {
+	hash := sha256.Sum256([]byte(value))
+	return base64.RawURLEncoding.EncodeToString(hash[:])
 }
 
 // isHttpSpecifier returns true if the specifier is a remote URL.

--- a/test/build-args/alias.test.ts
+++ b/test/build-args/alias.test.ts
@@ -1,11 +1,24 @@
-import { assertEquals, assertStringIncludes } from "jsr:@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "jsr:@std/assert";
 
 Deno.test("types with ?alias", async () => {
+  const url = "http://localhost:8080/@emotion/styled@11.11.5/types/base.d.ts";
+  const plain = await fetch(url).then((res) => res.text());
+  const queryRes = await fetch(
+    url + "?alias=react:preact/compat&deps=preact@10.6.6",
+  );
+  assertEquals(queryRes.status, 200);
+  const queryTypes = await queryRes.text();
+  assertStringIncludes(queryTypes, "preact@10.6.6/compat/src/index.d.ts");
+  assert(queryTypes !== plain);
+
   const res = await fetch(
     `http://localhost:8080/@emotion/styled@11.11.5/X-YXJlYWN0OnByZWFjdC9jb21wYXQKZHByZWFjdEAxMC42LjY/types/base.d.ts`,
   );
   assertEquals(res.status, 200);
-  assertEquals(res.headers.get("Content-type"), "application/typescript; charset=utf-8");
+  assertEquals(
+    res.headers.get("Content-type"),
+    "application/typescript; charset=utf-8",
+  );
   const ts = await res.text();
   assertStringIncludes(ts, "preact@10.6.6/compat/src/index.d.ts");
 });

--- a/test/build-args/deps.test.ts
+++ b/test/build-args/deps.test.ts
@@ -7,10 +7,10 @@ Deno.test("?deps", async () => {
     assertStringIncludes(code, 'import "/react-dom@18.2.0/X-ZHJlYWN0QDE4LjIuMA/es2022/react-dom.mjs"');
     assertStringIncludes(code, 'import "/react@18.2.0/es2022/jsx-runtime.mjs"');
     assertStringIncludes(code, 'import "/react@18.2.0/es2022/react.mjs"');
-    assertStringIncludes(code, 'import "/react-transition-group@^4.4.5?deps=react-dom@18.2.0,react@18.2.0&target=es2022"');
+    assertStringIncludes(code, 'import "/react-transition-group@^4.4.5?deps=react-dom%4018.2.0%2Creact%4018.2.0&target=es2022"');
     assertStringIncludes(code, 'export * from "/@mui/material@5.16.7/X-ZHJlYWN0LWRvbUAxOC4yLjAscmVhY3RAMTguMi4w/es2022/material.mjs"');
-    assertStringIncludes(code, 'import "/@mui/system@^5.16.7/createTheme?deps=react@18.2.0&target=es2022"');
-    assertStringIncludes(code, 'import "/@mui/utils@^5.16.6/useTimeout?deps=react@18.2.0&target=es2022"');
+    assertStringIncludes(code, 'import "/@mui/system@^5.16.7/createTheme?deps=react%4018.2.0&target=es2022"');
+    assertStringIncludes(code, 'import "/@mui/utils@^5.16.6/useTimeout?deps=react%4018.2.0&target=es2022"');
   }
   {
     const res = await fetch("http://localhost:8080/@mui/material@5.16.7/X-ZHJlYWN0LWRvbUAxOC4yLjAscmVhY3RAMTguMi4w/es2022/material.mjs");
@@ -18,9 +18,9 @@ Deno.test("?deps", async () => {
     assertStringIncludes(code, 'from"/react-dom@18.2.0/X-ZHJlYWN0QDE4LjIuMA/es2022/react-dom.mjs"');
     assertStringIncludes(code, 'from"/react@18.2.0/es2022/jsx-runtime.mjs"');
     assertStringIncludes(code, 'from"/react@18.2.0/es2022/react.mjs"');
-    assertStringIncludes(code, 'from"/react-transition-group@^4.4.5?deps=react-dom@18.2.0,react@18.2.0&target=es2022"');
-    assertStringIncludes(code, 'from"/@mui/system@^5.16.7/createTheme?deps=react@18.2.0&target=es2022"');
-    assertStringIncludes(code, 'from"/@mui/utils@^5.16.6/useTimeout?deps=react@18.2.0&target=es2022"');
+    assertStringIncludes(code, 'from"/react-transition-group@^4.4.5?deps=react-dom%4018.2.0%2Creact%4018.2.0&target=es2022"');
+    assertStringIncludes(code, 'from"/@mui/system@^5.16.7/createTheme?deps=react%4018.2.0&target=es2022"');
+    assertStringIncludes(code, 'from"/@mui/utils@^5.16.6/useTimeout?deps=react%4018.2.0&target=es2022"');
   }
 });
 
@@ -31,7 +31,7 @@ Deno.test("?deps in TypeScript types", async () => {
   assert(dtsUrl, "X-TypeScript-Types header should be present");
   assertStringIncludes(dtsUrl, "/X-", "DTS URL should include X-<hash> encoded build args");
 
-  const dtsRes = await fetch(dtsUrl);
+  const dtsRes = await fetch(new URL(dtsUrl, res.url));
   const dtsCode = await dtsRes.text();
   assertStringIncludes(dtsCode, "@mui/utils", "DTS should import from @mui/utils");
   assertStringIncludes(

--- a/test/build-args/package-css.test.ts
+++ b/test/build-args/package-css.test.ts
@@ -3,7 +3,7 @@ import { assert, assertEquals } from "jsr:@std/assert";
 Deno.test("package css", async () => {
   const res = await fetch("http://localhost:8080/monaco-editor@0.40.0?css&target=es2022", { redirect: "manual" });
   assertEquals(res.status, 301);
-  assertEquals(res.headers.get("location"), "http://localhost:8080/monaco-editor@0.40.0/es2022/monaco-editor.css");
+  assertEquals(res.headers.get("location"), "/monaco-editor@0.40.0/es2022/monaco-editor.css");
   res.body?.cancel();
 
   const res2 = await fetch("http://localhost:8080/monaco-editor@0.40.0/es2022/monaco-editor.css", { redirect: "manual" });

--- a/test/build-args/web-worker.test.ts
+++ b/test/build-args/web-worker.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "jsr:@std/assert";
 
 import workerFactory from "http://localhost:8080/xxhash-wasm@1.0.2?worker";
 
@@ -41,4 +41,29 @@ Deno.test("web-worker", async () => {
   });
   assertEquals(hashText, "502b0c5fc4a5704c");
   worker.terminate();
+});
+
+Deno.test("web-worker output ignores forwarded origin", async () => {
+  const entryUrl = "http://localhost:8080/xxhash-wasm@1.0.2?target=es2022";
+  const entryRes = await fetch(entryUrl);
+  entryRes.body?.cancel();
+  const buildPath = entryRes.headers.get("x-esm-path");
+  assert(buildPath);
+
+  for (const url of [
+    entryUrl + "&worker&origin-regression",
+    new URL(buildPath + "?worker&origin-regression", entryUrl),
+  ]) {
+    const res = await fetch(url, {
+      headers: {
+        "X-Real-Origin": `https://attacker.invalid" } = options; globalThis.PWNED = true; const { z = "`,
+      },
+    });
+    const code = await res.text();
+    assertEquals(res.status, 200);
+    assertStringIncludes(code, "new URL(\"/");
+    assertStringIncludes(code, "JSON.stringify(moduleUrl)");
+    assert(!code.includes("attacker.invalid"));
+    assert(!code.includes("globalThis.PWNED"));
+  }
 });

--- a/test/dts/dts-header.test.ts
+++ b/test/dts/dts-header.test.ts
@@ -1,11 +1,15 @@
 import { assertEquals, assertStringIncludes } from "jsr:@std/assert";
 
 Deno.test("dts header", async () => {
-  const res = await fetch("http://localhost:8080/@jridgewell/trace-mapping@0.3.31");
+  const res = await fetch("http://localhost:8080/@jridgewell/trace-mapping@0.3.31?origin-regression", {
+    headers: {
+      "X-Real-Origin": `https://attacker.invalid" } = options; globalThis.PWNED = true; const { z = "`,
+    },
+  });
   res.body?.cancel();
   assertEquals(res.status, 200);
   assertEquals(res.headers.get("content-type"), "application/javascript; charset=utf-8");
-  assertEquals(res.headers.get("x-typescript-types"), "http://localhost:8080/@jridgewell/trace-mapping@0.3.31/types/trace-mapping.d.mts");
-  const dts = await fetch(res.headers.get("x-typescript-types")!).then((r) => r.text());
+  assertEquals(res.headers.get("x-typescript-types"), "/@jridgewell/trace-mapping@0.3.31/types/trace-mapping.d.mts");
+  const dts = await fetch(new URL(res.headers.get("x-typescript-types")!, res.url)).then((r) => r.text());
   assertStringIncludes(dts, `'./sourcemap-segment.d.mts'`);
 });

--- a/test/dts/types-only.test.ts
+++ b/test/dts/types-only.test.ts
@@ -2,13 +2,22 @@ import { assertEquals, assertStringIncludes } from "jsr:@std/assert";
 
 Deno.test("types only", async () => {
   const res = await fetch(
-    "http://localhost:8080/@octokit-next/types-rest-api@2.5.0",
+    "http://localhost:8080/@octokit-next/types-rest-api@2.5.0?origin-regression",
+    {
+      headers: {
+        "X-Real-Origin": `https://attacker.invalid" } = options; globalThis.PWNED = true; const { z = "`,
+      },
+    },
   );
   res.body?.cancel();
   assertEquals(res.status, 200);
   assertEquals(res.headers.get("content-type"), "application/javascript; charset=utf-8");
-  const dtsUrl = `http://localhost:8080/@octokit-next/types-rest-api@2.5.0/index.d.ts`;
+  const dtsUrl = `/@octokit-next/types-rest-api@2.5.0/index.d.ts`;
   assertEquals(res.headers.get("x-typescript-types"), dtsUrl);
-  const dts = await fetch(dtsUrl).then((r) => r.text());
-  assertStringIncludes(dts, `declare module "http://localhost:8080/@octokit-next/types@2.5.0/index.d.ts"`);
+  const dts = await fetch(new URL(dtsUrl, res.url), {
+    headers: {
+      "X-Real-Origin": "https://attacker.invalid",
+    },
+  }).then((r) => r.text());
+  assertStringIncludes(dts, `declare module "/@octokit-next/types@2.5.0/index.d.ts"`);
 });

--- a/test/dts/types-versions.test.ts
+++ b/test/dts/types-versions.test.ts
@@ -4,11 +4,11 @@ Deno.test("typesVersions", async () => {
   {
     const res = await fetch("http://localhost:8080/@redux-saga/core@1.3.0");
     res.body?.cancel();
-    assertEquals(res.headers.get("x-typescript-types"), "http://localhost:8080/@redux-saga/core@1.3.0/types/ts4.2/index.d.ts");
+    assertEquals(res.headers.get("x-typescript-types"), "/@redux-saga/core@1.3.0/types/ts4.2/index.d.ts");
   }
   {
     const res = await fetch("http://localhost:8080/web-streams-polyfill@3.3.3");
     res.body?.cancel();
-    assertEquals(res.headers.get("x-typescript-types"), "http://localhost:8080/web-streams-polyfill@3.3.3/dist/types/ts3.6/polyfill.d.ts");
+    assertEquals(res.headers.get("x-typescript-types"), "/web-streams-polyfill@3.3.3/dist/types/ts3.6/polyfill.d.ts");
   }
 });

--- a/test/fixed-url/test.ts
+++ b/test/fixed-url/test.ts
@@ -27,7 +27,7 @@ Deno.test("redirect semantic versioning module for deno target", async () => {
     res.body?.cancel();
     assertEquals(res.status, 302);
     assertEquals(res.headers.get("cache-control"), "public, max-age=600");
-    assertStringIncludes(res.headers.get("location")!, "http://localhost:8080/preact@");
+    assertStringIncludes(res.headers.get("location")!, "/preact@");
     assertStringIncludes(res.headers.get("vary") ?? "", "User-Agent");
   }
 
@@ -50,9 +50,9 @@ Deno.test("redirect asset URLs", async () => {
     res.body?.cancel();
     assertEquals(res.status, 302);
     assertEquals(res.headers.get("cache-control"), "public, max-age=600");
-    assertStringIncludes(res.headers.get("location")!, "http://localhost:8080/react@");
+    assertStringIncludes(res.headers.get("location")!, "/react@");
 
-    const res2 = await fetch(res.headers.get("location")!, { redirect: "manual" });
+    const res2 = await fetch(new URL(res.headers.get("location")!, res.url), { redirect: "manual" });
     const pkg = await res2.json();
     assertEquals(res2.status, 200);
     assertEquals(res2.headers.get("cache-control"), "public, max-age=31536000, immutable");
@@ -63,9 +63,9 @@ Deno.test("redirect asset URLs", async () => {
     res.body?.cancel();
     assertEquals(res.status, 302);
     assertEquals(res.headers.get("cache-control"), "public, max-age=600");
-    assertStringIncludes(res.headers.get("location")!, "http://localhost:8080/react@18.");
+    assertStringIncludes(res.headers.get("location")!, "/react@18.");
 
-    const res2 = await fetch(res.headers.get("location")!, { redirect: "manual" });
+    const res2 = await fetch(new URL(res.headers.get("location")!, res.url), { redirect: "manual" });
     const pkg = await res2.json();
     assertEquals(res2.status, 200);
     assertEquals(res2.headers.get("cache-control"), "public, max-age=31536000, immutable");
@@ -76,10 +76,10 @@ Deno.test("redirect asset URLs", async () => {
     res.body?.cancel();
     assertEquals(res.status, 302);
     assertEquals(res.headers.get("cache-control"), "public, max-age=600");
-    assertStringIncludes(res.headers.get("location")!, "http://localhost:8080/react@");
+    assertStringIncludes(res.headers.get("location")!, "/react@");
     assert(res.headers.get("location")!.endsWith("/package.json?module"));
 
-    const res2 = await fetch(res.headers.get("location")!, { redirect: "manual" });
+    const res2 = await fetch(new URL(res.headers.get("location")!, res.url), { redirect: "manual" });
     const js = await res2.text();
     assertEquals(res2.status, 200);
     assertEquals(res2.headers.get("cache-control"), "public, max-age=31536000, immutable");
@@ -91,7 +91,7 @@ Deno.test("redirect asset URLs", async () => {
     res.body?.cancel();
     assertEquals(res.status, 301);
     assertEquals(res.headers.get("cache-control"), "public, max-age=31536000, immutable");
-    assertEquals(res.headers.get("location")!, "http://localhost:8080/@lezer/highlight@1.2.1/dist/index.js?raw");
+    assertEquals(res.headers.get("location")!, "/@lezer/highlight@1.2.1/dist/index.js?raw");
   }
 });
 
@@ -105,7 +105,7 @@ Deno.test("Fix wasm URLs with `target` segment", async () => {
     assertEquals(res.status, 301);
     assertEquals(
       res.headers.get("location"),
-      "http://localhost:8080/lightningcss-wasm@1.19.0/lightningcss_node.wasm",
+      "/lightningcss-wasm@1.19.0/lightningcss_node.wasm",
     );
   }
   {
@@ -117,7 +117,7 @@ Deno.test("Fix wasm URLs with `target` segment", async () => {
     assertEquals(res.status, 301);
     assertEquals(
       res.headers.get("location"),
-      "http://localhost:8080/esm-compiler@0.7.2/pkg/esm_compiler_bg.wasm",
+      "/esm-compiler@0.7.2/pkg/esm_compiler_bg.wasm",
     );
   }
   {
@@ -129,7 +129,7 @@ Deno.test("Fix wasm URLs with `target` segment", async () => {
     assertEquals(res.status, 301);
     assertEquals(
       res.headers.get("location"),
-      "http://localhost:8080/gh/oxc-project/oxc@7d785c3/napi/parser/parser.wasm32-wasi.wasm",
+      "/gh/oxc-project/oxc@7d785c3/napi/parser/parser.wasm32-wasi.wasm",
     );
   }
 });
@@ -143,7 +143,7 @@ Deno.test("Fix json URLs with `target` segment", async () => {
   assertEquals(res.status, 301);
   assertEquals(
     res.headers.get("location"),
-    "http://localhost:8080/lightningcss-wasm@1.19.0/package.json",
+    "/lightningcss-wasm@1.19.0/package.json",
   );
 });
 
@@ -173,7 +173,7 @@ Deno.test("redirect to css entry", async () => {
   const res = await fetch("http://localhost:8080/@markprompt/css@0.33.0", { redirect: "manual" });
   res.body?.cancel();
   assertEquals(res.status, 301);
-  assertEquals(res.headers.get("location"), "http://localhost:8080/@markprompt/css@0.33.0/markprompt.css");
+  assertEquals(res.headers.get("location"), "/@markprompt/css@0.33.0/markprompt.css");
 });
 
 Deno.test("[workaround] force the dependency version of react equals to react-dom", async () => {

--- a/test/issue-165/test.ts
+++ b/test/issue-165/test.ts
@@ -7,5 +7,5 @@ Deno.test("issue #165", async () => {
   assertEquals(res.status, 200);
   const code = await res.text();
   assertStringIncludes(code, "/react@18.1.0/");
-  assertStringIncludes(code, "deps=react@18.1.0");
+  assertStringIncludes(code, "deps=react%4018.1.0");
 });

--- a/test/issue-576/test.ts
+++ b/test/issue-576/test.ts
@@ -4,5 +4,5 @@ Deno.test("issue #576", async () => {
   const res = await fetch(`http://localhost:8080/dedent@0.7.0`);
   const tsHeader = res.headers.get("x-typescript-types");
   res.body?.cancel();
-  assertEquals(tsHeader, `http://localhost:8080/@types/dedent@~0.7.2/index.d.ts`);
+  assertEquals(tsHeader, `/@types/dedent@~0.7.2/index.d.ts`);
 });

--- a/test/issue-578/test.ts
+++ b/test/issue-578/test.ts
@@ -6,6 +6,6 @@ Deno.test("issue #578", async () => {
   const esmPathHeader = res.headers.get("X-Esm-Path");
   assertEquals(esmPathHeader, "/katex@0.16.4/esnext/katex.mjs");
   const tsHeader = res.headers.get("x-typescript-types");
-  assert(tsHeader?.startsWith("http://localhost:8080/@types/katex@~0.16"));
+  assert(tsHeader?.startsWith("/@types/katex@~0.16"));
   assert(tsHeader?.endsWith("/index.d.ts"));
 });

--- a/test/issue-580/test.ts
+++ b/test/issue-580/test.ts
@@ -2,10 +2,10 @@ import { assertEquals, assertStringIncludes } from "jsr:@std/assert";
 
 Deno.test("issue #580", async () => {
   let res = await fetch(`http://localhost:8080/pocketbase@0.13.1`);
-  const dtsUrl = `http://localhost:8080/pocketbase@0.13.1/dist/pocketbase.es.d.mts`;
+  const dtsUrl = `/pocketbase@0.13.1/dist/pocketbase.es.d.mts`;
   const dtsHeader = res.headers.get("x-typescript-types");
   res.body?.cancel();
   assertEquals(dtsHeader, dtsUrl);
-  const dts = await fetch(dtsUrl).then((res) => res.text());
+  const dts = await fetch(new URL(dtsUrl, res.url)).then((res) => res.text());
   assertStringIncludes(dts, "declare function getTokenPayload");
 });

--- a/test/issue-589/test.ts
+++ b/test/issue-589/test.ts
@@ -10,7 +10,7 @@ Deno.test("issue #589", async () => {
   assertEquals(res.status, 302);
   assert(
     res.headers.get("location")!.startsWith(
-      `http://localhost:8080/@types/react@18.`,
+      `/@types/react@18.`,
     ),
   );
 });

--- a/test/issue-606/test.ts
+++ b/test/issue-606/test.ts
@@ -8,7 +8,7 @@ Deno.test("issue #606", async (t) => {
     res.body?.cancel();
     assertEquals(
       res.headers.get("x-typescript-types")!,
-      `http://localhost:8080/@sinclair/typebox@0.28.5/typebox.d.ts`,
+      `/@sinclair/typebox@0.28.5/typebox.d.ts`,
     );
   });
 
@@ -19,7 +19,7 @@ Deno.test("issue #606", async (t) => {
     res.body?.cancel();
     assertEquals(
       res.headers.get("x-typescript-types")!,
-      `http://localhost:8080/@sinclair/typebox@0.28.5/value/index.d.ts`,
+      `/@sinclair/typebox@0.28.5/value/index.d.ts`,
     );
   });
 });

--- a/test/issue-638/test.ts
+++ b/test/issue-638/test.ts
@@ -8,7 +8,7 @@ Deno.test("issue #638", async () => {
   assertEquals(res.status, 301);
   assertEquals(
     res.headers.get("location")!,
-    "http://localhost:8080/@sqlite.org/sqlite-wasm@3.41.2/sqlite-wasm/jswasm/sqlite3.wasm",
+    "/@sqlite.org/sqlite-wasm@3.41.2/sqlite-wasm/jswasm/sqlite3.wasm",
   );
   res.body?.cancel();
 });

--- a/test/issue-671/test.ts
+++ b/test/issue-671/test.ts
@@ -1,4 +1,4 @@
-import { assertStringIncludes } from "jsr:@std/assert";
+import { assert, assertStringIncludes } from "jsr:@std/assert";
 
 Deno.test("issue #671", async () => {
   const res = await fetch(
@@ -6,18 +6,37 @@ Deno.test("issue #671", async () => {
   );
   await res.body?.cancel();
   const esmPath = res.headers.get("x-esm-path");
-  const code = await fetch("http://localhost:8080" + esmPath).then((res) => res.text());
-  assertStringIncludes(code, 'from"/preact/compat/jsx-runtime?target=denonext"');
-  assertStringIncludes(code, 'from"/preact/compat?target=denonext"');
-  assertStringIncludes(code, '"/react-icons@^4.10.1/hi?alias=react:preact/compat&target=denonext"');
+  const code = await fetch("http://localhost:8080" + esmPath).then((res) =>
+    res.text()
+  );
+  const match = code.match(
+    /from"\/preact@([^/]+)\/denonext\/compat\/jsx-runtime\.mjs"/,
+  );
+  assert(match);
+  const version = match[1];
+  assertStringIncludes(code, `from"/preact@${version}/denonext/compat.mjs"`);
+  assertStringIncludes(
+    code,
+    `"/react-icons@^4.10.1/hi?alias=${
+      encodeURIComponent(`react:preact@${version}/compat`)
+    }&target=denonext"`,
+  );
 
   const res2 = await fetch(
     "http://localhost:8080/flowbite-react@v0.4.9?alias=react:preact/compat,react-dom:preact/compat&deps=preact@10.0.0&target=es2020",
   );
   await res2.body?.cancel();
   const esmPath2 = res2.headers.get("x-esm-path");
-  const code2 = await fetch("http://localhost:8080" + esmPath2).then((res) => res.text());
-  assertStringIncludes(code2, 'from"/preact@10.0.0/es2020/compat/jsx-runtime.mjs"');
+  const code2 = await fetch("http://localhost:8080" + esmPath2).then((res) =>
+    res.text()
+  );
+  assertStringIncludes(
+    code2,
+    'from"/preact@10.0.0/es2020/compat/jsx-runtime.mjs"',
+  );
   assertStringIncludes(code2, 'from"/preact@10.0.0/es2020/compat.mjs"');
-  assertStringIncludes(code2, 'hi?alias=react:preact/compat&deps=preact@10.0.0&target=es2020"');
+  assertStringIncludes(
+    code2,
+    'hi?alias=react%3Apreact%4010.0.0%2Fcompat&deps=preact%4010.0.0&target=es2020"',
+  );
 });

--- a/test/issue-741/test.ts
+++ b/test/issue-741/test.ts
@@ -10,13 +10,13 @@ Deno.test("issue #741", async () => {
     const res = await fetch("http://localhost:8080/@sinclair/typebox@0.32.22?no-bundle");
     res.body?.cancel();
     assertEquals(res.ok, true);
-    assertEquals(res.headers.get("x-typescript-types"), "http://localhost:8080/@sinclair/typebox@0.32.22/build/import/index.d.mts");
+    assertEquals(res.headers.get("x-typescript-types"), "/@sinclair/typebox@0.32.22/build/import/index.d.mts");
   }
   {
     const res = await fetch("http://localhost:8080/@sinclair/typebox@0.32.22/value?no-bundle");
     res.body?.cancel();
     assertEquals(res.ok, true);
-    assertEquals(res.headers.get("x-typescript-types"), "http://localhost:8080/@sinclair/typebox@0.32.22/build/import/value/index.d.mts");
+    assertEquals(res.headers.get("x-typescript-types"), "/@sinclair/typebox@0.32.22/build/import/value/index.d.mts");
   }
   {
     const Foo = { [Kind]: "Foo" } as TSchema;

--- a/test/issue-765/test.ts
+++ b/test/issue-765/test.ts
@@ -7,7 +7,7 @@ Deno.test("issue #765", async () => {
 
   assertStringIncludes(
     dts,
-    `http://localhost:8080/openai@4.20.0/resources/index.d.ts`,
+    `/openai@4.20.0/resources/index.d.ts`,
   );
 
   const dts2 = await fetch(

--- a/test/issue-791/test.ts
+++ b/test/issue-791/test.ts
@@ -3,5 +3,5 @@ import { assertEquals } from "jsr:@std/assert";
 Deno.test("issue #791", async () => {
   const res = await fetch("http://localhost:8080/@vueuse/shared@10.7.2");
   res.body?.cancel();
-  assertEquals(res.headers.get("x-typescript-types"), "http://localhost:8080/@vueuse/shared@10.7.2/index.d.cts");
+  assertEquals(res.headers.get("x-typescript-types"), "/@vueuse/shared@10.7.2/index.d.cts");
 });

--- a/test/jsr/std.test.ts
+++ b/test/jsr/std.test.ts
@@ -15,6 +15,6 @@ Deno.test("jsr subpath", async () => {
 Deno.test("jsr raw path", async () => {
   const res = await fetch("http://localhost:8080/jsr.io/@std/assert@1.0.10/mod.ts");
   assertEquals(res.status, 200);
-  assertEquals(res.headers.get("x-typescript-types"), "http://localhost:8080/@jsr/std__assert@1.0.10/_dist/mod.d.ts");
+  assertEquals(res.headers.get("x-typescript-types"), "/@jsr/std__assert@1.0.10/_dist/mod.d.ts");
   assertStringIncludes(await res.text(), "/@jsr/std__assert@1.0.10/denonext/mod.ts.mjs");
 });

--- a/test/legacy-routes/test.ts
+++ b/test/legacy-routes/test.ts
@@ -47,7 +47,7 @@ Deno.test("legacy routes (cache hit)", async () => {
     }),
   );
   await writeTextFile(
-    ".esmd/storage/legacy/react-dom@19.2.5.y35WJGFJWuY.meta",
+    ".esmd/storage/legacy/react-dom@19.2.5.VwhfCQHI1gcHWW6bPkA0_iVlHThtWHfo-4kbLQSxB_4.meta",
     JSON.stringify({
       "esmId": "v135/react-dom@19.2.5/X-ZS9yZWFjdA/es2022/react-dom.mjs",
       "dts": "/v135/@types/react-dom@~19.2/X-ZS9yZWFjdA/index.d.ts",
@@ -56,17 +56,23 @@ Deno.test("legacy routes (cache hit)", async () => {
     }),
   );
   await writeTextFile(".esmd/storage/legacy/v135/react@19.2.5/es2022/react.js", "export const version = '19.2.5';");
-  await writeTextFile(".esmd/storage/legacy/v135/@types/react@19.2.5/index.d.ts", "export const version:string;");
+  await writeTextFile(
+    ".esmd/storage/legacy/v135/@types/react@19.2.5/index.d.ts",
+    'export * from "https://esm.sh/v135/@types/react@19.2.5/global.d.ts";',
+  );
 
   {
     const res = await fetch("http://localhost:8080/v135/react@19.0.0", {
       redirect: "manual",
-      headers: { "User-Agent": "i'm a browser" },
+      headers: {
+        "User-Agent": "i'm a browser",
+        "X-Real-Origin": "https://attacker.invalid",
+      },
     });
     const text = await res.text();
     assertEquals(res.status, 200);
     assertEquals(res.headers.get("x-esm-id"), "stable/react@19.0.0/es2022/react.mjs");
-    assertEquals(res.headers.get("x-typescript-types"), "http://localhost:8080/v135/@types/react@latest/index.d.ts");
+    assertEquals(res.headers.get("x-typescript-types"), "/v135/@types/react@latest/index.d.ts");
     assertEquals(
       text,
       '/* esm.sh - react@19.0.0 */\nexport * from "/stable/react@19.0.0/es2022/react.mjs";\nexport { default } from "/stable/react@19.0.0/es2022/react.mjs";\n',
@@ -81,7 +87,7 @@ Deno.test("legacy routes (cache hit)", async () => {
     const text = await res.text();
     assertEquals(res.status, 200);
     assertEquals(res.headers.get("x-esm-id"), "v135/react-dom@19.2.5/X-ZS9yZWFjdA/es2022/react-dom.mjs");
-    assertEquals(res.headers.get("x-typescript-types"), "http://localhost:8080/v135/@types/react-dom@~19.2/X-ZS9yZWFjdA/index.d.ts");
+    assertEquals(res.headers.get("x-typescript-types"), "/v135/@types/react-dom@~19.2/X-ZS9yZWFjdA/index.d.ts");
     assertEquals(text, '/* esm.sh - react-dom@19.2.5 */\nexport * from "/v135/react-dom@19.2.5/X-ZS9yZWFjdA/es2022/react-dom.mjs";\nexport { default } from "/v135/react-dom@19.2.5/X-ZS9yZWFjdA/es2022/react-dom.mjs";\n');
   }
 
@@ -100,7 +106,7 @@ Deno.test("legacy routes (cache hit)", async () => {
     });
     const text = await res.text();
     assertEquals(res.status, 200);
-    assertEquals(text, "export const version:string;");
+    assertEquals(text, 'export * from "/v135/@types/react@19.2.5/global.d.ts";');
   }
 });
 
@@ -111,7 +117,7 @@ Deno.test("legacy routes (cache miss)", async () => {
     });
     res.body?.cancel();
     assertEquals(res.status, 301);
-    assert(res.headers.get("Location")?.startsWith("http://localhost:8080/react@18.3.1"));
+    assert(res.headers.get("Location")?.startsWith("/react@18.3.1"));
   }
   {
     const res = await fetch("http://localhost:8080/v135/react@18.3.1", {
@@ -119,7 +125,7 @@ Deno.test("legacy routes (cache miss)", async () => {
     });
     res.body?.cancel();
     assertEquals(res.status, 301);
-    assert(res.headers.get("Location")?.startsWith("http://localhost:8080/react@18.3.1"));
+    assert(res.headers.get("Location")?.startsWith("/react@18.3.1"));
   }
   {
     const res = await fetch("http://localhost:8080/v135/react@18.3.1?target=2018", {
@@ -127,7 +133,7 @@ Deno.test("legacy routes (cache miss)", async () => {
     });
     res.body?.cancel();
     assertEquals(res.status, 301);
-    assert(res.headers.get("Location")?.startsWith("http://localhost:8080/react@18.3.1?target=2018"));
+    assert(res.headers.get("Location")?.startsWith("/react@18.3.1?target=2018"));
   }
   {
     const res = await fetch("http://localhost:8080/stable/react", {
@@ -135,7 +141,7 @@ Deno.test("legacy routes (cache miss)", async () => {
     });
     res.body?.cancel();
     assertEquals(res.status, 302);
-    assert(res.headers.get("Location")?.startsWith("http://localhost:8080/stable/react@"));
+    assert(res.headers.get("Location")?.startsWith("/stable/react@"));
   }
   {
     const res = await fetch("http://localhost:8080/v135/react@18", {
@@ -143,7 +149,7 @@ Deno.test("legacy routes (cache miss)", async () => {
     });
     res.body?.cancel();
     assertEquals(res.status, 302);
-    assert(res.headers.get("Location")?.startsWith("http://localhost:8080/v135/react@18."));
+    assert(res.headers.get("Location")?.startsWith("/v135/react@18."));
   }
   {
     const res = await fetch("http://localhost:8080/v135/node_process.js", {
@@ -152,7 +158,7 @@ Deno.test("legacy routes (cache miss)", async () => {
     });
     res.body?.cancel();
     assertEquals(res.status, 301);
-    assert(res.headers.get("Location")?.startsWith("http://localhost:8080/node/process.mjs"));
+    assert(res.headers.get("Location")?.startsWith("/node/process.mjs"));
   }
   {
     const res = await fetch("http://localhost:8080/v135/node.ns.d.ts", {

--- a/test/origin/test.ts
+++ b/test/origin/test.ts
@@ -1,0 +1,62 @@
+import { assert, assertEquals, assertStringIncludes } from "jsr:@std/assert";
+
+const poison =
+  `https://attacker.invalid" } = options; globalThis.PWNED = true; const { z = "`;
+
+Deno.test("landing page is origin-neutral", async () => {
+  const poisoned = await fetch("http://localhost:8080/", {
+    headers: {
+      "User-Agent": "Mozilla/5.0",
+      "X-Real-Origin": poison,
+    },
+  });
+  const poisonedHtml = await poisoned.text();
+  assertEquals(poisoned.status, 200);
+  assertStringIncludes(
+    poisonedHtml,
+    `.replaceAll("https://esm.sh", location.origin)`,
+  );
+  assert(!poisonedHtml.includes("attacker.invalid"));
+  assert(!poisonedHtml.includes("globalThis.PWNED"));
+
+  const honestHtml = await fetch("http://localhost:8080/", {
+    headers: {
+      "User-Agent": "Mozilla/5.0",
+    },
+  }).then((res) => res.text());
+  assertEquals(honestHtml, poisonedHtml);
+});
+
+Deno.test("WASM module wrapper resolves against import.meta.url", async () => {
+  const res = await fetch(
+    "http://localhost:8080/esm-compiler@0.7.2/pkg/esm_compiler_bg.wasm?module&origin-regression",
+    {
+      headers: {
+        "X-Real-Origin": poison,
+      },
+    },
+  );
+  const code = await res.text();
+  assertEquals(res.status, 200);
+  assertStringIncludes(
+    code,
+    `fetch(new URL("/esm-compiler@0.7.2/pkg/esm_compiler_bg.wasm", import.meta.url))`,
+  );
+  assert(!code.includes("attacker.invalid"));
+  assert(!code.includes("globalThis.PWNED"));
+});
+
+Deno.test("redirects are root-relative", async () => {
+  const res = await fetch("http://localhost:8080/react@^18.3.1/package.json", {
+    redirect: "manual",
+    headers: {
+      "X-Real-Origin": poison,
+    },
+  });
+  const location = res.headers.get("location");
+  res.body?.cancel();
+  assertEquals(res.status, 302);
+  assert(location);
+  assert(location.startsWith("/react@18."));
+  assert(!location.includes("attacker.invalid"));
+});


### PR DESCRIPTION
- Harden npm resolution, build argument handling, metadata, and request routing.
- Address edge cases involving aliases, dependencies, CSS packages, workers, TypeScript declarations, fixed URLs, and legacy routes.
- Add regression coverage for the reported security issue and related routing/build scenarios.