### PR TITLE
Prevent security-origin bypasses in CDN request handling

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -18,6 +18,7 @@ To configure the server, create a `config.json` file then pass it to the server 
 // config.json
 {
   "port": 8080,
+  "cdnOrigin": "https://esm.example.com",
   "npmRegistry": "https://registry.npmjs.org/",
   "npmToken": "******"
 }
@@ -65,14 +66,15 @@ docker pull ghcr.io/esm-dev/esm.sh:v137   # specified stable version
 docker pull ghcr.io/esm-dev/esm.sh:dev    # latest dev version
 ```
 
-Run the container:
+Run the container with its public origin:
 
 ```bash
-docker run -p 80:80 ghcr.io/esm-dev/esm.sh:latest
+docker run -e CDN_ORIGIN=https://esm.example.com -p 80:80 ghcr.io/esm-dev/esm.sh:latest
 ```
 
 Available environment variables:
 
+- `CDN_ORIGIN`: The public origin of the CDN, for example `https://esm.example.com`. Self-hosted deployments should always set this.
 - `COMPRESS`: Compress http responses with gzip/brotli, default is `true`.
 - `CUSTOM_LANDING_PAGE_ORIGIN`: The custom landing page origin, default is empty.
 - `CUSTOM_LANDING_PAGE_ASSETS`: The custom landing page assets separated by comma(,), default is empty.

--- a/config.example.jsonc
+++ b/config.example.jsonc
@@ -7,6 +7,10 @@
   // Note: if you are running the server in a docker container, you need to expose port `443:443`.
   "tlsPort": 0,
 
+  // The public origin of this CDN. It must include the protocol and must not include a path.
+  // The fallback is the local server address; public deployments should always set this.
+  "cdnOrigin": "https://esm.example.com",
+
   // Allowed CORS origins, default is allow all origins.
   // Note: A valid origin must be a valid URL, including the protocol, domain, and port. e.g. "https://example.com".
   "corsAllowOrigins": [],

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -24,6 +24,7 @@ type Storage interface {
 	Stat(key string) (stat Stat, err error)
 	Get(key string) (content io.ReadCloser, stat Stat, err error)
 	Put(key string, r io.Reader) error
+	PutIfAbsent(key string, r io.Reader) (created bool, err error)
 	Delete(key string) error
 	List(prefix string) (keys []string, err error)
 	DeleteAll(prefix string) (deletedKeys []string, err error)

--- a/internal/storage/storage_fs.go
+++ b/internal/storage/storage_fs.go
@@ -81,26 +81,58 @@ func (fs *fsStorage) Get(key string) (content io.ReadCloser, stat Stat, err erro
 }
 
 func (fs *fsStorage) Put(key string, content io.Reader) (err error) {
+	_, err = fs.put(key, content, false)
+	return
+}
+
+func (fs *fsStorage) PutIfAbsent(key string, content io.Reader) (created bool, err error) {
+	return fs.put(key, content, true)
+}
+
+func (fs *fsStorage) put(key string, content io.Reader, exclusive bool) (created bool, err error) {
 	filename, err := fs.joinRootSafe(key)
 	if err != nil {
-		return err
+		return
 	}
 	err = ensureDir(filepath.Dir(filename))
 	if err != nil {
 		return
 	}
+	if exclusive {
+		_, err = os.Lstat(filename)
+		if err == nil {
+			return false, nil
+		}
+		if !os.IsNotExist(err) {
+			return false, err
+		}
+	}
 
-	file, err := os.Create(filename)
+	file, err := os.CreateTemp(filepath.Dir(filename), ".tmp-*")
 	if err != nil {
 		return
 	}
-
+	tempName := file.Name()
+	defer os.Remove(tempName)
 	_, err = io.Copy(file, content)
-	file.Close()
-	if err != nil {
-		os.Remove(filename) // clean up if error occurs
+	if err == nil {
+		err = file.Chmod(0644)
 	}
-	return
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return false, err
+	}
+	if exclusive {
+		err = os.Link(tempName, filename)
+		if errors.Is(err, os.ErrExist) {
+			return false, nil
+		}
+		return err == nil, err
+	}
+	err = os.Rename(tempName, filename)
+	return err == nil, err
 }
 
 func (fs *fsStorage) Delete(key string) (err error) {
@@ -169,6 +201,9 @@ func findFiles(root string, parentDir string) ([]string, error) {
 	var files []string
 	for _, entry := range entries {
 		name := entry.Name()
+		if !entry.IsDir() && strings.HasPrefix(name, ".tmp-") {
+			continue
+		}
 		path := name
 		if parentDir != "" {
 			path = parentDir + "/" + name

--- a/internal/storage/storage_fs_test.go
+++ b/internal/storage/storage_fs_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path"
@@ -116,6 +117,106 @@ func TestFSStorage(t *testing.T) {
 	}
 }
 
+func TestFSStoragePutIfAbsent(t *testing.T) {
+	fs, err := NewFSStorage(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := fs.PutIfAbsent("locked/module.mjs", bytes.NewBufferString("first"))
+	if err != nil || !created {
+		t.Fatalf("first PutIfAbsent: created %v, err %v", created, err)
+	}
+	created, err = fs.PutIfAbsent("locked/module.mjs", bytes.NewBufferString("second"))
+	if err != nil || created {
+		t.Fatalf("second PutIfAbsent: created %v, err %v", created, err)
+	}
+
+	r, _, err := fs.Get("locked/module.mjs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, readErr := io.ReadAll(r)
+	closeErr := r.Close()
+	if readErr != nil || closeErr != nil || string(data) != "first" {
+		t.Fatalf("stored content %q, read err %v, close err %v", data, readErr, closeErr)
+	}
+
+	created, err = fs.PutIfAbsent("locked/empty.mjs", bytes.NewReader(nil))
+	if err != nil || !created {
+		t.Fatalf("empty PutIfAbsent: created %v, err %v", created, err)
+	}
+	created, err = fs.PutIfAbsent("locked/empty.mjs", bytes.NewBufferString("replacement"))
+	if err != nil || created {
+		t.Fatalf("empty replacement: created %v, err %v", created, err)
+	}
+	fi, err := fs.Stat("locked/empty.mjs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Size() != 0 {
+		t.Fatalf("empty stored size %v", fi.Size())
+	}
+
+	type result struct {
+		created bool
+		err     error
+	}
+	results := make(chan result, 32)
+	for i := range 32 {
+		go func() {
+			created, err := fs.PutIfAbsent("locked/concurrent.mjs", bytes.NewReader([]byte{byte(i)}))
+			results <- result{created, err}
+		}()
+	}
+	createdCount := 0
+	for range 32 {
+		result := <-results
+		if result.err != nil {
+			t.Fatal(result.err)
+		}
+		if result.created {
+			createdCount++
+		}
+	}
+	if createdCount != 1 {
+		t.Fatalf("concurrent PutIfAbsent created %d files", createdCount)
+	}
+	fi, err = fs.Stat("locked/concurrent.mjs")
+	if err != nil || fi.Size() != 1 {
+		t.Fatalf("concurrent stored size is not one byte: %v", err)
+	}
+
+	if err = fs.Put("locked/atomic.meta", bytes.NewBufferString("first")); err != nil {
+		t.Fatal(err)
+	}
+	if err = fs.Put("locked/atomic.meta", failingReader{}); err == nil {
+		t.Fatal("expected failed overwrite")
+	}
+	r, _, err = fs.Get("locked/atomic.meta")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, readErr = io.ReadAll(r)
+	r.Close()
+	if readErr != nil || string(data) != "first" {
+		t.Fatalf("failed Put changed existing content: %q, err %v", data, readErr)
+	}
+
+	if err = os.WriteFile(path.Join(fs.(*fsStorage).root, ".tmp-orphan"), []byte("partial"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	keys, err := fs.List("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range keys {
+		if key == ".tmp-orphan" {
+			t.Fatal("temporary storage file was listed")
+		}
+	}
+}
+
 func TestFSStorageRejectPathTraversal(t *testing.T) {
 	root := path.Join(os.TempDir(), "storage_traversal_"+rand.Hex.String(8))
 	fs, err := NewFSStorage(root)
@@ -145,6 +246,9 @@ func TestFSStorageRejectPathTraversal(t *testing.T) {
 		if err = fs.Delete(k); err != ErrInvalidStorageKey {
 			t.Fatalf("Delete(%q): want ErrInvalidStorageKey, got %v", k, err)
 		}
+		if _, err = fs.PutIfAbsent(k, bytes.NewBufferString("evil")); err != ErrInvalidStorageKey {
+			t.Fatalf("PutIfAbsent(%q): want ErrInvalidStorageKey, got %v", k, err)
+		}
 	}
 
 	err = fs.Put("ok/sub/file.txt", bytes.NewBufferString("hi"))
@@ -160,4 +264,10 @@ func TestFSStorageRejectPathTraversal(t *testing.T) {
 	if err != nil || string(b) != "hi" {
 		t.Fatalf("Get ok path: content %q err %v", string(b), err)
 	}
+}
+
+type failingReader struct{}
+
+func (failingReader) Read(p []byte) (int, error) {
+	return copy(p, "partial"), errors.New("read failed")
 }

--- a/internal/storage/storage_s3.go
+++ b/internal/storage/storage_s3.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -230,67 +231,113 @@ func (s3 *s3Storage) Get(name string) (content io.ReadCloser, stat Stat, err err
 }
 
 func (s3 *s3Storage) Put(name string, content io.Reader) (err error) {
+	_, err = s3.put(name, content, false)
+	return
+}
+
+func (s3 *s3Storage) PutIfAbsent(name string, content io.Reader) (created bool, err error) {
+	return s3.put(name, content, true)
+}
+
+func (s3 *s3Storage) put(name string, content io.Reader, exclusive bool) (created bool, err error) {
 	if name == "" {
-		return errors.New("name is required")
+		return false, errors.New("name is required")
 	}
-	var contentLength int64
+	var body io.ReadSeeker
 	if buf, ok := content.(*bytes.Buffer); ok {
-		contentLength = int64(buf.Len())
-	} else if seeker, ok := content.(io.Seeker); ok {
-		var size int64
-		size, err = seeker.Seek(0, io.SeekEnd)
-		if err != nil {
-			return
-		}
-		_, err = seeker.Seek(0, io.SeekStart)
-		if err != nil {
-			return
-		}
-		contentLength = size
+		body = bytes.NewReader(buf.Next(buf.Len()))
+	} else if seeker, ok := content.(io.ReadSeeker); ok {
+		body = seeker
 	} else if reader, ok := content.(*teeReader); ok {
 		if buf, ok := reader.r.(*bytes.Buffer); ok {
-			contentLength = int64(buf.Len())
-		} else if seeker, ok := reader.r.(io.Seeker); ok {
-			var size int64
-			size, err = seeker.Seek(0, io.SeekEnd)
-			if err != nil {
-				return
+			data := buf.Next(buf.Len())
+			n, e := reader.w.Write(data)
+			if e != nil {
+				return false, e
 			}
-			_, err = seeker.Seek(0, io.SeekStart)
-			if err != nil {
-				return
+			if n != len(data) {
+				return false, io.ErrShortWrite
 			}
-			contentLength = size
+			body = bytes.NewReader(data)
 		} else {
-			return errors.New("missing content length")
+			data, e := io.ReadAll(reader)
+			if e != nil {
+				return false, e
+			}
+			body = bytes.NewReader(data)
 		}
 	} else {
-		err = errors.New("missing content length")
-		return
+		return false, errors.New("missing content length")
 	}
-	if s3.shouldUseFSCache(name) {
-		cacheKey := s3.fsCacheKey(name)
-		pr, pw := io.Pipe()
-		go func(content io.Reader) {
-			unlock := s3.fsCacheLock.Lock(name)
-			defer unlock()
-			err := s3.fsCache.Put(cacheKey, io.TeeReader(content, pw))
-			pw.CloseWithError(err)
-		}(content)
-		content = pr
-	}
-	req, _ := http.NewRequest("PUT", s3.apiEndpoint+"/"+name, content)
-	s3.sign(req)
-	req.ContentLength = contentLength
-	resp, err := http.DefaultClient.Do(req)
+	contentLength, err := body.Seek(0, io.SeekEnd)
 	if err != nil {
-		return
+		return false, err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 400 {
-		return parseS3Error(resp)
+	for attempt := 0; attempt < 2; attempt++ {
+		_, err = body.Seek(0, io.SeekStart)
+		if err != nil {
+			return false, err
+		}
+		var requestBody io.Reader = body
+		if !exclusive && s3.shouldUseFSCache(name) {
+			cacheKey := s3.fsCacheKey(name)
+			pr, pw := io.Pipe()
+			go func(content io.Reader) {
+				unlock := s3.fsCacheLock.Lock(name)
+				defer unlock()
+				err := s3.fsCache.Put(cacheKey, io.TeeReader(content, pw))
+				pw.CloseWithError(err)
+			}(requestBody)
+			requestBody = pr
+		}
+		req, _ := http.NewRequest("PUT", s3.apiEndpoint+"/"+name, requestBody)
+		if exclusive {
+			req.Header.Set("If-None-Match", "*")
+		}
+		s3.sign(req)
+		req.ContentLength = contentLength
+		resp, e := http.DefaultClient.Do(req)
+		if e != nil {
+			return false, e
+		}
+		if exclusive && resp.StatusCode == http.StatusConflict && attempt == 0 {
+			resp.Body.Close()
+			continue
+		}
+		if exclusive && resp.StatusCode == http.StatusPreconditionFailed {
+			resp.Body.Close()
+			if err = s3.invalidateFSCache(name); err != nil {
+				return false, err
+			}
+			return false, nil
+		}
+		if resp.StatusCode >= 400 {
+			err = parseS3Error(resp)
+			resp.Body.Close()
+			return false, err
+		}
+		resp.Body.Close()
+		if exclusive {
+			if err = s3.invalidateFSCache(name); err != nil {
+				return false, err
+			}
+		}
+		return true, nil
 	}
-	return nil
+	return false, errors.New("conditional put conflict")
+}
+
+func (s3 *s3Storage) invalidateFSCache(name string) error {
+	if !s3.shouldUseFSCache(name) {
+		return nil
+	}
+	unlock := s3.fsCacheLock.Lock(name)
+	defer unlock()
+	err := s3.fsCache.Delete(s3.fsCacheKey(name))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
 }
 
 func (s3 *s3Storage) Delete(name string) (err error) {

--- a/internal/storage/storage_s3_test.go
+++ b/internal/storage/storage_s3_test.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"bytes"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 )
@@ -17,6 +19,72 @@ func TestS3StorageFSCacheKey(t *testing.T) {
 	}
 	if got = s3.fsCacheKey("v135/react@19.2.0/esnext/react.mjs"); got != "v135/react@19.2.0/esnext/react.mjs" {
 		t.Fatalf("invalid cache key %q", got)
+	}
+}
+
+func TestS3StoragePutIfAbsent(t *testing.T) {
+	stored := map[string][]byte{}
+	conflict := true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("If-None-Match") != "*" {
+			t.Errorf("missing If-None-Match header")
+		}
+		if r.URL.Path == "/retry.mjs" && conflict {
+			conflict = false
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Error(err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if _, ok := stored[r.URL.Path]; ok {
+			w.WriteHeader(http.StatusPreconditionFailed)
+			return
+		}
+		stored[r.URL.Path] = data
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	s3, err := NewS3Storage(&StorageOptions{
+		Type:            "s3",
+		Endpoint:        server.URL,
+		Region:          "auto",
+		AccessKeyID:     "test",
+		SecretAccessKey: "test",
+		CacheDir:        t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := s3.PutIfAbsent("module.mjs", bytes.NewBufferString("first"))
+	if err != nil || !created {
+		t.Fatalf("first PutIfAbsent: created %v, err %v", created, err)
+	}
+	backend := s3.(*s3Storage)
+	if err = backend.fsCache.Put("module.mjs", bytes.NewBufferString("stale")); err != nil {
+		t.Fatal(err)
+	}
+	created, err = s3.PutIfAbsent("module.mjs", bytes.NewBufferString("second"))
+	if err != nil || created {
+		t.Fatalf("second PutIfAbsent: created %v, err %v", created, err)
+	}
+	if string(stored["/module.mjs"]) != "first" {
+		t.Fatalf("stored content was overwritten: %q", stored["/module.mjs"])
+	}
+	if _, err = backend.fsCache.Stat("module.mjs"); err != ErrNotFound {
+		t.Fatalf("stale filesystem cache was not invalidated: %v", err)
+	}
+
+	created, err = s3.PutIfAbsent("retry.mjs", bytes.NewBufferString("retried"))
+	if err != nil || !created {
+		t.Fatalf("retried PutIfAbsent: created %v, err %v", created, err)
+	}
+	if string(stored["/retry.mjs"]) != "retried" {
+		t.Fatalf("unexpected retry content: %q", stored["/retry.mjs"])
 	}
 }
 
@@ -59,13 +127,21 @@ func TestS3Storage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	created, err := s3.PutIfAbsent(dirname+"/locked.txt", bytes.NewBufferString("first"))
+	if err != nil || !created {
+		t.Fatalf("first PutIfAbsent: created %v, err %v", created, err)
+	}
+	created, err = s3.PutIfAbsent(dirname+"/locked.txt", bytes.NewBufferString("second"))
+	if err != nil || created {
+		t.Fatalf("second PutIfAbsent: created %v, err %v", created, err)
+	}
 
 	keys, err := s3.List(dirname + "/")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(keys) != 3 {
-		t.Fatalf("invalid keys length(%d), expected 3", len(keys))
+	if len(keys) != 4 {
+		t.Fatalf("invalid keys length(%d), expected 4", len(keys))
 	}
 
 	stat, err := s3.Stat(dirname + "/hello.txt")
@@ -120,11 +196,25 @@ func TestS3Storage(t *testing.T) {
 		t.Fatalf("invalid content(%s), expected 'foobar~'", string(data))
 	}
 
+	r, _, err = s3.Get(dirname + "/locked.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err = io.ReadAll(r)
+	r.Close()
+	if err != nil || string(data) != "first" {
+		t.Fatalf("invalid locked content(%s), expected 'first'", string(data))
+	}
+
 	err = s3.Delete(dirname + "/hello.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
 	err = s3.Delete(dirname + "/%23/hello+world!")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s3.Delete(dirname + "/locked.txt")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/build.go
+++ b/server/build.go
@@ -87,7 +87,42 @@ var loaders = map[string]esbuild.Loader{
 	".woff2":  esbuild.LoaderDataURL,
 }
 
+func encodeJSONModule(data []byte) ([]byte, error) {
+	if !json.Valid(data) {
+		return nil, errors.New("invalid JSON module")
+	}
+	encoded := utils.MustEncodeJSON(json.RawMessage(data))
+	return concatBytes([]byte("export default "), bytes.TrimSuffix(encoded, []byte{'\n'})), nil
+}
+
+func putImmutable(store storage.Storage, key string, data []byte) ([]byte, error) {
+	created, err := store.PutIfAbsent(key, bytes.NewReader(data))
+	if err != nil || created {
+		return data, err
+	}
+	r, _, err := store.Get(key)
+	if err != nil {
+		return nil, err
+	}
+	stored, err := io.ReadAll(r)
+	if closeErr := r.Close(); err == nil {
+		err = closeErr
+	}
+	return stored, err
+}
+
+func putImmutableExact(store storage.Storage, key string, data []byte) error {
+	stored, err := putImmutable(store, key, data)
+	if err == nil && !bytes.Equal(stored, data) {
+		return fmt.Errorf("immutable storage conflict: %s", key)
+	}
+	return err
+}
+
 func (ctx *BuildContext) Path() string {
+	if len(ctx.args.Conditions) > 1 {
+		sort.Strings(ctx.args.Conditions)
+	}
 	if ctx.path != "" {
 		return ctx.path
 	}
@@ -304,16 +339,29 @@ func (ctx *BuildContext) buildModule(analyzeMode bool) (meta *BuildMeta, include
 			err = fmt.Errorf("could not resolve module %s", entry.main)
 			return
 		}
+		savePath := ctx.getSavePath()
+		// A stored module is immutable even if its metadata was lost.
+		_, statErr := ctx.storage.Stat(savePath)
+		if statErr == nil {
+			meta = &BuildMeta{ExportDefault: true}
+			return
+		} else if statErr != storage.ErrNotFound {
+			ctx.logger.Errorf("storage.stat(%s): %v", savePath, statErr)
+			err = errors.New("storage(stat): " + statErr.Error())
+			return
+		}
 		jsonData, err = os.ReadFile(jsonPath)
 		if err != nil {
 			return
 		}
-		buffer := &bytes.Buffer{}
-		buffer.WriteString("export default ")
-		buffer.Write(jsonData)
-		err = ctx.storage.Put(ctx.getSavePath(), buffer)
+		var module []byte
+		module, err = encodeJSONModule(jsonData)
 		if err != nil {
-			ctx.logger.Errorf("storage.put(%s): %v", ctx.getSavePath(), err)
+			return
+		}
+		_, err = ctx.storage.PutIfAbsent(savePath, bytes.NewReader(module))
+		if err != nil {
+			ctx.logger.Errorf("storage.put(%s): %v", savePath, err)
 			err = errors.New("storage(put): " + err.Error())
 			return
 		}
@@ -367,13 +415,16 @@ func (ctx *BuildContext) buildModule(analyzeMode bool) (meta *BuildMeta, include
 		if meta.ExportDefault {
 			fmt.Fprintf(buf, `export { default } from "%s";`, importUrl)
 		}
-		err = ctx.storage.Put(ctx.getSavePath(), buf)
+		meta.Dts, err = ctx.resolveDTS(entry)
+		if err != nil {
+			return
+		}
+		err = putImmutableExact(ctx.storage, ctx.getSavePath(), buf.Bytes())
 		if err != nil {
 			ctx.logger.Errorf("storage.put(%s): %v", ctx.getSavePath(), err)
 			err = errors.New("storage(put): " + err.Error())
 			return
 		}
-		meta.Dts, err = ctx.resolveDTS(entry)
 		return
 	}
 
@@ -1249,6 +1300,7 @@ REBUILD:
 	}
 
 	imports := set.New[string]()
+	var jsOutputs []*bytes.Buffer
 
 	for _, file := range res.OutputFiles {
 		if strings.HasSuffix(file.Path, ".js") {
@@ -1483,39 +1535,20 @@ REBUILD:
 				finalJS.WriteString(path.Base(ctx.Path()))
 				finalJS.WriteString(".map")
 			}
-
-			var stat storage.Stat
-			stat, err = ctx.storage.Stat(ctx.getSavePath())
-			if err == nil && stat.Size() > 0 {
-				ctx.logger.Infof("build(%s): file already exists in the storage, skip it", ctx.Path())
-				continue
-			}
-			if err != storage.ErrNotFound {
-				ctx.logger.Errorf("storage.stat(%s): %v", ctx.getSavePath(), err)
-				err = errors.New("storage(stat): " + err.Error())
-				return
-			}
-			sha := sha512.New384()
-			err = ctx.storage.Put(ctx.getSavePath(), storage.TeeReader(finalJS, sha))
-			if err != nil {
-				ctx.logger.Errorf("storage.put(%s): %v", ctx.getSavePath(), err)
-				err = errors.New("storage(put): " + err.Error())
-				return
-			}
-			meta.Integrity = "sha384-" + base64.StdEncoding.EncodeToString(sha.Sum(nil))
+			jsOutputs = append(jsOutputs, finalJS)
 		}
 	}
 
+	type sidecar struct {
+		path string
+		data []byte
+	}
+	var sidecars []sidecar
 	for _, file := range res.OutputFiles {
 		if strings.HasSuffix(file.Path, ".css") {
 			savePath := ctx.getSavePath()
 			savePath = strings.TrimSuffix(savePath, path.Ext(savePath)) + ".css"
-			err = ctx.storage.Put(savePath, bytes.NewReader(file.Contents))
-			if err != nil {
-				ctx.logger.Errorf("storage.put(%s): %v", savePath, err)
-				err = errors.New("storage(put): " + err.Error())
-				return
-			}
+			sidecars = append(sidecars, sidecar{savePath, file.Contents})
 			meta.CSSInJS = true
 		} else if config.SourceMap && strings.HasSuffix(file.Path, ".js.map") {
 			var sourceMap map[string]any
@@ -1530,12 +1563,7 @@ REBUILD:
 				}
 				buf := &bytes.Buffer{}
 				if json.NewEncoder(buf).Encode(sourceMap) == nil {
-					err = ctx.storage.Put(ctx.getSavePath()+".map", buf)
-					if err != nil {
-						ctx.logger.Errorf("storage.put(%s): %v", ctx.getSavePath()+".map", err)
-						err = errors.New("storage(put): " + err.Error())
-						return
-					}
+					sidecars = append(sidecars, sidecar{ctx.getSavePath() + ".map", buf.Bytes()})
 				}
 			}
 		}
@@ -1551,6 +1579,88 @@ REBUILD:
 
 	// resolve types(dts)
 	meta.Dts, err = ctx.resolveDTS(entry)
+	if err != nil {
+		return
+	}
+
+	if len(jsOutputs) > 0 {
+		main := jsOutputs[0].Bytes()
+		for _, output := range jsOutputs[1:] {
+			if !bytes.Equal(main, output.Bytes()) {
+				err = errors.New("build produced multiple module outputs")
+				return
+			}
+		}
+
+		savePath := ctx.getSavePath()
+		var stored []byte
+		var exists bool
+		var f io.ReadCloser
+		f, _, err = ctx.storage.Get(savePath)
+		if err == nil {
+			exists = true
+			stored, err = io.ReadAll(f)
+			if closeErr := f.Close(); err == nil {
+				err = closeErr
+			}
+		} else if err == storage.ErrNotFound {
+			err = nil
+		}
+		if err != nil {
+			ctx.logger.Errorf("storage.get(%s): %v", savePath, err)
+			err = errors.New("storage(get): " + err.Error())
+			return
+		}
+
+		if !exists {
+			for _, sidecar := range sidecars {
+				f, _, err = ctx.storage.Get(sidecar.path)
+				if err == storage.ErrNotFound {
+					err = nil
+					continue
+				}
+				if err != nil {
+					ctx.logger.Errorf("storage.get(%s): %v", sidecar.path, err)
+					err = errors.New("storage(get): " + err.Error())
+					return
+				}
+				data, readErr := io.ReadAll(f)
+				if closeErr := f.Close(); readErr == nil {
+					readErr = closeErr
+				}
+				if readErr != nil {
+					err = errors.New("storage(get): " + readErr.Error())
+					return
+				}
+				if !bytes.Equal(data, sidecar.data) {
+					err = fmt.Errorf("immutable storage conflict: %s", sidecar.path)
+					return
+				}
+			}
+			stored, err = putImmutable(ctx.storage, savePath, main)
+			if err != nil {
+				ctx.logger.Errorf("storage.put(%s): %v", savePath, err)
+				err = errors.New("storage(put): " + err.Error())
+				return
+			}
+		}
+
+		if !bytes.Equal(stored, main) {
+			err = fmt.Errorf("immutable storage conflict: %s", savePath)
+			return
+		}
+		sha := sha512.Sum384(stored)
+		meta.Integrity = "sha384-" + base64.StdEncoding.EncodeToString(sha[:])
+	}
+
+	for _, sidecar := range sidecars {
+		err = putImmutableExact(ctx.storage, sidecar.path, sidecar.data)
+		if err != nil {
+			ctx.logger.Errorf("storage.put(%s): %v", sidecar.path, err)
+			err = errors.New("storage(put): " + err.Error())
+			return
+		}
+	}
 	return
 }
 

--- a/server/build_args_test.go
+++ b/server/build_args_test.go
@@ -50,3 +50,25 @@ func TestEncodeBuildArgs(t *testing.T) {
 		t.Fatal("ignoreAnnotations should be true")
 	}
 }
+
+func TestBuildPathCanonicalizesConditions(t *testing.T) {
+	a := &BuildContext{
+		esmPath: EsmPath{PkgName: "pkg", PkgVersion: "1.0.0"},
+		args:    BuildArgs{Conditions: []string{"react-server", "browser"}},
+		target:  "es2022",
+	}
+	b := &BuildContext{
+		esmPath: EsmPath{PkgName: "pkg", PkgVersion: "1.0.0"},
+		args:    BuildArgs{Conditions: []string{"browser", "react-server"}},
+		target:  "es2022",
+	}
+	const want = "/pkg@1.0.0/X-Y2Jyb3dzZXIscmVhY3Qtc2VydmVy/es2022/pkg.mjs"
+	if a.Path() != want || b.Path() != want {
+		t.Fatal("condition permutations must use the same build path")
+	}
+	for _, ctx := range []*BuildContext{a, b} {
+		if ctx.args.Conditions[0] != "browser" || ctx.args.Conditions[1] != "react-server" {
+			t.Fatalf("conditions were not canonicalized: %v", ctx.args.Conditions)
+		}
+	}
+}

--- a/server/build_test.go
+++ b/server/build_test.go
@@ -1,17 +1,21 @@
 package server
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/esm-dev/esm.sh/internal/npm"
 	"github.com/esm-dev/esm.sh/internal/storage"
+	"github.com/ije/gox/log"
 )
 
-func TestBuildModuleJSONPathTraversal(t *testing.T) {
+func TestBuildJSONModule(t *testing.T) {
 	root := t.TempDir()
 	wd := filepath.Join(root, "wd")
 	pkgName := "traversal-pkg"
@@ -83,5 +87,216 @@ func TestBuildModuleJSONPathTraversal(t *testing.T) {
 	}
 	if string(data) != `export default {"safe":true}` {
 		t.Fatalf("unexpected module output: %s", data)
+	}
+
+	if err := os.WriteFile(filepath.Join(pkgDir, "injected.json"), []byte(`{"safe":true};globalThis.PWNED=1`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	ctx = &BuildContext{
+		storage: fs,
+		wd:      wd,
+		esmPath: EsmPath{
+			PkgName:    pkgName,
+			PkgVersion: "1.0.0",
+			SubPath:    "injected.json",
+		},
+		pkgJson: pkgJson,
+		path:    "injected.mjs",
+	}
+	meta, _, err = ctx.buildModule(false)
+	if err == nil {
+		t.Fatal("expected injected JSON to be rejected")
+	}
+	if meta != nil {
+		t.Fatal("expected no build metadata")
+	}
+	if _, err := fs.Stat(ctx.getSavePath()); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("expected no injected module in storage, got %v", err)
+	}
+
+	ctx = &BuildContext{
+		storage: fs,
+		wd:      wd,
+		esmPath: EsmPath{
+			PkgName:    pkgName,
+			PkgVersion: "1.0.0",
+			SubPath:    "injected.json",
+		},
+		pkgJson: pkgJson,
+		path:    "locked.mjs",
+	}
+	locked := []byte{}
+	if err := fs.Put(ctx.getSavePath(), bytes.NewReader(locked)); err != nil {
+		t.Fatal(err)
+	}
+	meta, _, err = ctx.buildModule(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta == nil || !meta.ExportDefault {
+		t.Fatal("expected build metadata for existing module")
+	}
+	f, _, err = fs.Get(ctx.getSavePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	data, err = io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, locked) {
+		t.Fatalf("existing module was overwritten: %s", data)
+	}
+}
+
+func TestEncodeJSONModule(t *testing.T) {
+	data := []byte("{\"html\":\"</script>\",\"line\":\"\u2028\u2029\"}")
+	module, err := encodeJSONModule(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(module, []byte("</script>")) || bytes.Contains(module, []byte{0xe2, 0x80, 0xa8}) || bytes.Contains(module, []byte{0xe2, 0x80, 0xa9}) {
+		t.Fatalf("unsafe JSON module: %s", module)
+	}
+	if _, err := encodeJSONModule([]byte(`{};globalThis.PWNED=1`)); err == nil {
+		t.Fatal("expected invalid JSON to be rejected")
+	}
+}
+
+func TestTransformDTSRepairsDependenciesWithoutOverwritingEntry(t *testing.T) {
+	root := t.TempDir()
+	wd := filepath.Join(root, "wd")
+	pkgDir := filepath.Join(wd, "node_modules", "types-pkg")
+	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "index.d.ts"), []byte(`export * from "./dep";`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "dep.d.ts"), []byte(`export type Value = string;`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fs, err := storage.NewFSStorage(filepath.Join(root, "storage"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const entryPath = "types/types-pkg@1.0.0/index.d.ts"
+	ctx := &BuildContext{
+		storage: fs,
+		wd:      wd,
+		esmPath: EsmPath{PkgName: "types-pkg", PkgVersion: "1.0.0"},
+	}
+	if _, err = transformDTS(ctx, "./index.d.ts", "", nil); err != nil {
+		t.Fatal(err)
+	}
+	entry, _, err := fs.Get(entryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	locked, err := io.ReadAll(entry)
+	entry.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const depPath = "types/types-pkg@1.0.0/dep.d.ts"
+	if err = fs.Delete(depPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = transformDTS(ctx, "./index.d.ts", "", nil); err != nil {
+		t.Fatal(err)
+	}
+	entry, _, err = fs.Get(entryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entryData, err := io.ReadAll(entry)
+	entry.Close()
+	if err != nil || !bytes.Equal(entryData, locked) {
+		t.Fatalf("stored entry changed: %q, err %v", entryData, err)
+	}
+	dep, _, err := fs.Get(depPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	depData, err := io.ReadAll(dep)
+	dep.Close()
+	if err != nil || !bytes.Contains(depData, []byte("Value")) {
+		t.Fatalf("dependency was not repaired: %q, err %v", depData, err)
+	}
+}
+
+func TestPutImmutableKeepsExistingObject(t *testing.T) {
+	fs, err := storage.NewFSStorage(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = fs.Put("module.mjs", strings.NewReader("first")); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := putImmutable(fs, "module.mjs", []byte("second"))
+	if err != nil || string(stored) != "first" {
+		t.Fatalf("unexpected immutable result %q, err %v", stored, err)
+	}
+	if err = putImmutableExact(fs, "module.mjs", []byte("second")); err == nil {
+		t.Fatal("expected immutable conflict")
+	}
+}
+
+func TestBuildRejectsImmutableModuleConflict(t *testing.T) {
+	root := t.TempDir()
+	wd := filepath.Join(root, "wd")
+	pkgDir := filepath.Join(wd, "node_modules", "locked-pkg")
+	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "index.js"), []byte(`export const value = 1;`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fs, err := storage.NewFSStorage(filepath.Join(root, "storage"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger, err := log.New("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := &BuildContext{
+		logger:  logger,
+		metaDB:  NewBuildMetaDB(fs),
+		storage: fs,
+		wd:      wd,
+		esmPath: EsmPath{
+			GhPrefix:   true,
+			PkgName:    "locked-pkg",
+			PkgVersion: "main",
+		},
+		pkgJson: &npm.PackageJSON{
+			Name:    "locked-pkg",
+			Version: "main",
+			Type:    "module",
+			Module:  "./index.js",
+		},
+		target: "es2022",
+		path:   "/locked-pkg@main/es2022/locked-pkg.mjs",
+	}
+	savePath := ctx.getSavePath()
+	if err = fs.Put(savePath, strings.NewReader("locked")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = ctx.Build(context.Background()); err == nil || !strings.Contains(err.Error(), "immutable storage conflict") {
+		t.Fatalf("expected immutable conflict, got %v", err)
+	}
+	f, _, err := fs.Get(savePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored, err := io.ReadAll(f)
+	f.Close()
+	if err != nil || string(stored) != "locked" {
+		t.Fatalf("stored module changed: %q, err %v", stored, err)
+	}
+	if _, err = ctx.metaDB.Get(ctx.Path()); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("conflicting metadata was published: %v", err)
 	}
 }

--- a/server/config.go
+++ b/server/config.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path"
@@ -27,6 +28,8 @@ var (
 type Config struct {
 	Port                uint16                       `json:"port"`
 	TlsPort             uint16                       `json:"tlsPort"`
+	CdnOrigin           string                       `json:"cdnOrigin"`
+	Origin              string                       `json:"origin,omitempty"`
 	CustomLandingPage   LandingPageOptions           `json:"customLandingPage"`
 	WorkDir             string                       `json:"workDir"`
 	CorsAllowOrigins    []string                     `json:"corsAllowOrigins"`
@@ -101,20 +104,79 @@ func LoadConfig(filename string) (*Config, error) {
 			return nil, fmt.Errorf("fail to get absolute path of the work directory: %w", err)
 		}
 	}
-	normalizeConfig(&config)
+	err = normalizeConfig(&config)
+	if err != nil {
+		return nil, err
+	}
 	return &config, nil
 }
 
 func DefaultConfig() *Config {
 	config := &Config{}
-	normalizeConfig(config)
+	if err := normalizeConfig(config); err != nil {
+		panic(err)
+	}
 	return config
 }
 
-func normalizeConfig(config *Config) {
+func normalizeConfig(config *Config) error {
 	if config.Port == 0 {
 		config.Port = 80
 	}
+	if config.CdnOrigin == "" {
+		config.CdnOrigin = config.Origin
+	}
+	if config.CdnOrigin == "" {
+		config.CdnOrigin = os.Getenv("CDN_ORIGIN")
+	}
+	if config.CdnOrigin == "" {
+		config.CdnOrigin = fmt.Sprintf("http://localhost:%d", config.Port)
+	}
+	u, err := url.Parse(config.CdnOrigin)
+	if err != nil {
+		return fmt.Errorf("invalid CDN origin: %q", config.CdnOrigin)
+	}
+	invalidOrigin := (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" || u.User != nil || (u.Path != "" && u.Path != "/") || u.RawPath != "" || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" || u.Opaque != ""
+	hostname := u.Hostname()
+	if hostname == "" {
+		invalidOrigin = true
+	} else if net.ParseIP(hostname) == nil {
+		domain := strings.TrimSuffix(hostname, ".")
+		if domain == "" || len(hostname) > 253 {
+			invalidOrigin = true
+		}
+		for label := range strings.SplitSeq(domain, ".") {
+			if len(label) == 0 || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+				invalidOrigin = true
+				break
+			}
+			for _, c := range label {
+				if !('a' <= c && c <= 'z') && !('A' <= c && c <= 'Z') && !('0' <= c && c <= '9') && c != '-' {
+					invalidOrigin = true
+					break
+				}
+			}
+		}
+	}
+	port := u.Port()
+	if port != "" {
+		n, e := strconv.Atoi(port)
+		if e != nil || n < 1 || n > 65535 || u.Host != net.JoinHostPort(hostname, port) {
+			invalidOrigin = true
+		}
+	} else {
+		host := hostname
+		if strings.Contains(hostname, ":") {
+			host = "[" + hostname + "]"
+		}
+		if u.Host != host {
+			invalidOrigin = true
+		}
+	}
+	if invalidOrigin {
+		return fmt.Errorf("invalid CDN origin: %q", config.CdnOrigin)
+	}
+	config.CdnOrigin = u.Scheme + "://" + u.Host
 	if config.WorkDir == "" {
 		if v := os.Getenv("ESMDIR"); v != "" && existsDir(v) {
 			config.WorkDir = v
@@ -257,6 +319,7 @@ func normalizeConfig(config *Config) {
 	config.Compress = !(bytes.Equal(config.CompressRaw, []byte("false")) || os.Getenv("COMPRESS") == "false")
 	config.SourceMap = !(bytes.Equal(config.SourceMapRaw, []byte("false")) || (os.Getenv("SOURCEMAP") == "false" || os.Getenv("SOURCE_MAP") == "false"))
 	config.Minify = !(bytes.Equal(config.MinifyRaw, []byte("false")) || os.Getenv("MINIFY") == "false")
+	return nil
 }
 
 // extractPackageName Will take a packageName as input extract key parts and return them

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -4,6 +4,57 @@ import (
 	"testing"
 )
 
+func TestCdnOrigin(t *testing.T) {
+	t.Setenv("CDN_ORIGIN", "")
+	for origin, want := range map[string]string{
+		"https://cdn.example.com/": "https://cdn.example.com",
+		"http://localhost:8080":    "http://localhost:8080",
+		"https://[::1]:8443":       "https://[::1]:8443",
+	} {
+		config := &Config{CdnOrigin: origin}
+		if err := normalizeConfig(config); err != nil {
+			t.Fatal(err)
+		}
+		if config.CdnOrigin != want {
+			t.Fatalf("unexpected CDN origin %q, want %q", config.CdnOrigin, want)
+		}
+	}
+
+	config := &Config{Origin: "https://legacy.example.com"}
+	if err := normalizeConfig(config); err != nil {
+		t.Fatal(err)
+	}
+	if config.CdnOrigin != config.Origin {
+		t.Fatalf("unexpected legacy CDN origin %q", config.CdnOrigin)
+	}
+
+	for _, origin := range []string{
+		"//cdn.example.com",
+		"https://:443",
+		"https://user@cdn.example.com",
+		`https://cdn.example";globalThis.PWNED=1;"`,
+		"https://cdn.example';globalThis.PWNED=1;'",
+		`https://cdn.example\evil`,
+		"https://bad_host.example",
+		"https://[cdn.example]",
+		"https://-cdn.example",
+		"https://cdn-.example",
+		"https://cdn.example:",
+		"https://cdn.example:0",
+		"https://cdn.example:65536",
+		"https://cdn.example.com/path",
+		"https://cdn.example.com?",
+		"https://cdn.example.com?query",
+		"https://cdn.example.com#fragment",
+		"javascript:alert(1)",
+		"https://cdn.example.com\r\nX-Pwned: 1",
+	} {
+		if err := normalizeConfig(&Config{CdnOrigin: origin}); err == nil {
+			t.Errorf("expected CDN origin %q to be rejected", origin)
+		}
+	}
+}
+
 func TestExtractPackageName(t *testing.T) {
 	type want struct {
 		packageId string

--- a/server/disk.go
+++ b/server/disk.go
@@ -21,8 +21,8 @@ const (
 // concurrent rename/remove races within this process.
 var npmStorePurgeLock sync.Mutex
 
-func purgeNPMCacheWhenDiskIsLowOrFull(npmrc *NpmRC, logger *log.Logger) {
-	if status := checkDiskStatus(); status == DiskStatusOk || status == DiskStatusError {
+func purgeNPMCacheWhenDiskIsLowOrFull(npmrc *NpmRC, logger *log.Logger, workDir string) {
+	if status := checkDiskStatus(workDir); status == DiskStatusOk || status == DiskStatusError {
 		return
 	}
 
@@ -50,9 +50,9 @@ func purgeNPMCacheWhenDiskIsLowOrFull(npmrc *NpmRC, logger *log.Logger) {
 	}
 }
 
-func checkDiskStatus() DiskStatus {
+func checkDiskStatus(workDir string) DiskStatus {
 	var stat syscall.Statfs_t
-	err := syscall.Statfs(config.WorkDir, &stat)
+	err := syscall.Statfs(workDir, &stat)
 	if err == nil {
 		avail := stat.Bavail * uint64(stat.Bsize)
 		if avail < 100*MB {

--- a/server/dts_transform.go
+++ b/server/dts_transform.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/esm-dev/esm.sh/internal/npm"
-	"github.com/esm-dev/esm.sh/internal/storage"
 	"github.com/ije/gox/set"
 	"github.com/ije/gox/utils"
 )
@@ -42,18 +41,14 @@ func transformDTS(ctx *BuildContext, dts string, buildArgsPrefix string, marker 
 	marker.Add(dtsPath)
 
 	savePath := normalizeSavePath(path.Join("types", dtsPath))
-	// check if the dts file has been transformed
-	_, err = ctx.storage.Stat(savePath)
-	if err == nil || err != storage.ErrNotFound {
-		return
-	}
-
 	dtsFilename := path.Join(ctx.wd, "node_modules", ctx.esmPath.PkgName, dts)
 	dtsContent, err := os.Open(dtsFilename)
 	if err != nil {
 		// if the dts file does not exist, print a warning but continue to build
 		if os.IsNotExist(err) {
-			if entry {
+			if _, storedErr := ctx.storage.Stat(savePath); storedErr == nil {
+				err = nil
+			} else if entry {
 				err = fmt.Errorf("types not found")
 			} else {
 				err = nil
@@ -254,28 +249,17 @@ func transformDTS(ctx *BuildContext, dts string, buildArgsPrefix string, marker 
 		return
 	}
 
-	err = ctx.storage.Put(savePath, ctx.rewriteDTS(dts, buffer))
-	if err != nil {
-		return
+	dependencies := deps.Values()
+	sort.Strings(dependencies)
+	for _, s := range dependencies {
+		var j int
+		j, err = transformDTS(ctx, "./"+path.Join(path.Dir(dts), s), buildArgsPrefix, marker)
+		if err != nil {
+			return
+		}
+		n += j
 	}
 
-	var wg sync.WaitGroup
-	var errors []error
-	for _, s := range deps.Values() {
-		wg.Add(1)
-		go func(s string) {
-			j, err := transformDTS(ctx, "./"+path.Join(path.Dir(dts), s), buildArgsPrefix, marker)
-			if err != nil {
-				errors = append(errors, err)
-			}
-			n += j
-			wg.Done()
-		}(s)
-	}
-	wg.Wait()
-
-	if len(errors) > 0 {
-		err = errors[0]
-	}
+	err = putImmutableExact(ctx.storage, savePath, ctx.rewriteDTS(dts, buffer).Bytes())
 	return
 }

--- a/server/legacy_router.go
+++ b/server/legacy_router.go
@@ -152,7 +152,7 @@ func legacyESM(ctx *rex.Context, fs storage.Storage, buildVersionPrefix string) 
 				return rex.Status(500, err.Error())
 			}
 			var b strings.Builder
-			b.WriteString(getOrigin(ctx))
+			b.WriteString(config.CdnOrigin)
 			if buildVersionPrefix != "" {
 				b.WriteByte('/')
 				b.WriteString(buildVersionPrefix)
@@ -191,7 +191,7 @@ func legacyESM(ctx *rex.Context, fs storage.Storage, buildVersionPrefix string) 
 				ctx.SetHeader("Content-Type", ctTypeScript)
 				// resolve hostname in typescript definition files if the origin is not "https://esm.sh"
 				if endsWith(pathname, ".d.ts", ".d.mts") {
-					origin := getOrigin(ctx)
+					origin := config.CdnOrigin
 					if origin != "https://esm.sh" {
 						defer f.Close()
 						data, err := io.ReadAll(f)
@@ -244,7 +244,7 @@ func legacyESM(ctx *rex.Context, fs storage.Storage, buildVersionPrefix string) 
 					ctx.SetHeader("X-ESM-Id", ret.EsmId)
 				}
 				if ret.Dts != "" {
-					ctx.SetHeader("X-TypeScript-Types", getOrigin(ctx)+ret.Dts)
+					ctx.SetHeader("X-TypeScript-Types", config.CdnOrigin+ret.Dts)
 				}
 				return ret.Code
 			}
@@ -253,7 +253,7 @@ func legacyESM(ctx *rex.Context, fs storage.Storage, buildVersionPrefix string) 
 
 	// strip leading `/stable/*` and `/v<build-version>/*`
 	if buildVersionPrefix != "" {
-		origin := getOrigin(ctx)
+		origin := config.CdnOrigin
 		if strings.HasPrefix(pathname, "/node_") && strings.HasSuffix(pathname, ".js") {
 			pathname = "/node/" + strings.TrimSuffix(strings.TrimPrefix(pathname, "/node_"), ".js") + ".mjs"
 		} else if pathname == "/node.ns.d.ts" {

--- a/server/path.go
+++ b/server/path.go
@@ -68,6 +68,24 @@ func parseEsmPath(npmrc *NpmRC, pathname string) (esm EsmPath, extraQuery string
 			err = errors.New("invalid path")
 			return
 		}
+		parts := strings.Split(pkgName, "/")
+		for i := 0; i < len(parts); i++ {
+			name := parts[i]
+			if name == "" || name == "." || name == ".." {
+				err = errors.New("invalid path")
+				return
+			}
+			if strings.HasPrefix(name, "@") {
+				i++
+				if i == len(parts) || parts[i] == "" || parts[i] == "." || parts[i] == ".." || !npm.ValidatePackageName(name+"/"+parts[i]) {
+					err = errors.New("invalid path")
+					return
+				}
+			} else if !npm.ValidatePackageName(name) {
+				err = errors.New("invalid path")
+				return
+			}
+		}
 		version, subPath := utils.SplitByFirstByte(rest, '/')
 		if version == "" || !npm.Versioning.Match(version) {
 			err = errors.New("invalid path")

--- a/server/path_test.go
+++ b/server/path_test.go
@@ -5,6 +5,34 @@ import (
 	"testing"
 )
 
+func TestParsePrPackageName(t *testing.T) {
+	for _, pathname := range []string{
+		"/pr/tinybench@abcdef0",
+		"/pr/tinylibs/tinybench/tinybench@abcdef0",
+		"/pr/owner/repo/@scope/pkg@abcdef0",
+	} {
+		esm, _, exact, _, _, err := parseEsmPath(nil, pathname)
+		if err != nil {
+			t.Errorf("parseEsmPath(%q): %v", pathname, err)
+		} else if !esm.PrPrefix || !exact {
+			t.Errorf("parseEsmPath(%q) did not return an exact PR package", pathname)
+		}
+	}
+
+	for _, pathname := range []string{
+		"/pr/../pkg@abcdef0",
+		"/pr/owner//pkg@abcdef0",
+		"/pr/owner/repo/..@abcdef0",
+		"/pr/owner/repo/bad%name@abcdef0",
+		"/pr/owner/repo/bad name@abcdef0",
+		"/pr/@scope/..@abcdef0",
+	} {
+		if _, _, _, _, _, err := parseEsmPath(nil, pathname); err == nil {
+			t.Errorf("expected PR package path %q to be rejected", pathname)
+		}
+	}
+}
+
 func TestPrCommitFromHeader(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/server/router.go
+++ b/server/router.go
@@ -65,17 +65,18 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 		buildQueue = NewBuildQueue(int(config.BuildConcurrency))
 		npmrc      = DefaultNpmRC()
 		metaDB     = NewBuildMetaDB(esmStorage)
+		workDir    = config.WorkDir
 	)
 
 	// purge npm cache when disk is low or full
 	go func() {
 		// run an initial check before waiting for the first ticker event
-		purgeNPMCacheWhenDiskIsLowOrFull(npmrc, logger)
+		purgeNPMCacheWhenDiskIsLowOrFull(npmrc, logger, workDir)
 
 		ticker := time.NewTicker(1 * time.Hour)
 		defer ticker.Stop()
 		for range ticker.C {
-			go purgeNPMCacheWhenDiskIsLowOrFull(npmrc, logger)
+			go purgeNPMCacheWhenDiskIsLowOrFull(npmrc, logger, workDir)
 		}
 	}()
 
@@ -163,13 +164,13 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 				}
 				if len(output.Map) > 0 {
 					output.Code = fmt.Sprintf("%s//# sourceMappingURL=+%s", output.Code, path.Base(savePath)+".map")
-					err = esmStorage.Put(savePath+".map", strings.NewReader(output.Map))
+					err = putImmutableExact(esmStorage, savePath+".map", []byte(output.Map))
 					if err != nil {
 						logger.Errorf("storage.put(%s): %v", savePath+".map", err)
 						return rex.Err(500, "failed to store source map")
 					}
 				}
-				err = esmStorage.Put(savePath, strings.NewReader(output.Code))
+				err = putImmutableExact(esmStorage, savePath, []byte(output.Code))
 				if err != nil {
 					logger.Errorf("storage.put(%s): %v", savePath, err)
 					return rex.Err(500, "failed to store transformed code")
@@ -253,7 +254,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 				}
 				readme = bytes.ReplaceAll(readme, []byte("./server/embed/"), []byte("/embed/"))
 				readme = bytes.ReplaceAll(readme, []byte("./HOSTING.md"), []byte("https://github.com/esm-dev/esm.sh/blob/main/HOSTING.md"))
-				readme = bytes.ReplaceAll(readme, []byte("https://esm.sh"), []byte(getOrigin(ctx)))
+				readme = bytes.ReplaceAll(readme, []byte("https://esm.sh"), []byte(config.CdnOrigin))
 				indexHTML, err = embedFS.ReadFile("embed/index.html")
 				if err != nil {
 					err = errors.New("failed to read index.html: " + err.Error())
@@ -277,7 +278,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 
 		case "/status.json":
 			diskStatus := "ok"
-			switch checkDiskStatus() {
+			switch checkDiskStatus(config.WorkDir) {
 			case DiskStatusFull:
 				diskStatus = "full"
 			case DiskStatusLow:
@@ -527,7 +528,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 			return rex.Status(403, "forbidden")
 		}
 
-		origin := getOrigin(ctx)
+		origin := config.CdnOrigin
 
 		registryPrefix := ""
 		if esmPath.GhPrefix {
@@ -875,7 +876,8 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 					return rex.Status(403, "File Too Large")
 				}
 				etag := fmt.Sprintf(`W/"%x-%x"`, stat.ModTime().Unix(), stat.Size())
-				if ifNoneMatch := ctx.R.Header.Get("If-None-Match"); ifNoneMatch == etag {
+				jsonModule := strings.HasSuffix(esmPath.SubPath, ".json") && query.Has("module")
+				if ifNoneMatch := ctx.R.Header.Get("If-None-Match"); !jsonModule && ifNoneMatch == etag {
 					return rex.Status(http.StatusNotModified, nil)
 				}
 				content, err := os.Open(filename)
@@ -894,19 +896,31 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 						ctx.SetHeader("Content-Type", contentType)
 					}
 				}
-				ctx.SetHeader("Content-Length", fmt.Sprintf("%d", stat.Size()))
-				ctx.SetHeader("Etag", etag)
-				ctx.SetHeader("Last-Modified", stat.ModTime().UTC().Format(http.TimeFormat))
-				ctx.SetHeader("Cache-Control", ccImmutable)
-				if strings.HasSuffix(esmPath.SubPath, ".json") && query.Has("module") {
+				if jsonModule {
 					defer content.Close()
 					jsonData, err := io.ReadAll(content)
 					if err != nil {
 						return rex.Status(500, err.Error())
 					}
+					module, err := encodeJSONModule(jsonData)
+					if err != nil {
+						ctx.SetHeader("Cache-Control", ccMustRevalidate)
+						return rex.Status(500, err.Error())
+					}
 					ctx.SetHeader("Content-Type", ctJavaScript)
-					return concatBytes([]byte("export default "), jsonData)
+					ctx.SetHeader("Etag", etag)
+					ctx.SetHeader("Last-Modified", stat.ModTime().UTC().Format(http.TimeFormat))
+					ctx.SetHeader("Cache-Control", ccImmutable)
+					if ctx.R.Header.Get("If-None-Match") == etag {
+						return rex.Status(http.StatusNotModified, nil)
+					}
+					ctx.SetHeader("Content-Length", fmt.Sprintf("%d", len(module)))
+					return module
 				}
+				ctx.SetHeader("Etag", etag)
+				ctx.SetHeader("Last-Modified", stat.ModTime().UTC().Format(http.TimeFormat))
+				ctx.SetHeader("Cache-Control", ccImmutable)
+				ctx.SetHeader("Content-Length", fmt.Sprintf("%d", stat.Size()))
 				return content // auto closed
 			}
 
@@ -961,11 +975,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 							if len(exports) > 0 {
 								moduleUrl += "?exports=" + strings.Join(exports, ",")
 							}
-							return fmt.Sprintf(
-								`export default function workerFactory(injectOrOptions) { const options = typeof injectOrOptions === "string" ? { inject: injectOrOptions }: injectOrOptions ?? {}; const { inject, name = "%s" } = options; const blob = new Blob(['import * as $module from "%s";', inject].filter(Boolean), { type: "application/javascript" }); return new Worker(URL.createObjectURL(blob), { type: "module", name })}`,
-								moduleUrl,
-								moduleUrl,
-							)
+							return newWorkerFactory(moduleUrl)
 						}
 						if len(exports) > 0 {
 							defer f.Close()
@@ -998,7 +1008,11 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 								return rex.Status(500, err.Error())
 							}
 							// note: the source map is dropped
-							go esmStorage.Put(savePath, bytes.NewReader(ret))
+							ret, err = putImmutable(esmStorage, savePath, ret)
+							if err != nil {
+								logger.Errorf("storage.put(%s): %v", savePath, err)
+								return rex.Status(500, "Storage error, please try again")
+							}
 							return ret
 						}
 					}
@@ -1469,11 +1483,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 					if !buildMeta.CJS && len(exports) > 0 {
 						moduleUrl += "?exports=" + strings.Join(exports, ",")
 					}
-					return fmt.Sprintf(
-						`export default function workerFactory(injectOrOptions) { const options = typeof injectOrOptions === "string" ? { inject: injectOrOptions }: injectOrOptions ?? {}; const { inject, name = "%s" } = options; const blob = new Blob(['import * as $module from "%s";', inject].filter(Boolean), { type: "application/javascript" }); return new Worker(URL.createObjectURL(blob), { type: "module", name })}`,
-						moduleUrl,
-						moduleUrl,
-					)
+					return newWorkerFactory(moduleUrl)
 				}
 				if noDts := query.Has("no-dts") || query.Has("no-check"); !noDts && buildMeta.Dts != "" {
 					ctx.SetHeader("X-TypeScript-Types", origin+buildMeta.Dts)
@@ -1501,7 +1511,11 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 					if err != nil {
 						return rex.Status(500, err.Error())
 					}
-					go esmStorage.Put(savePath, bytes.NewReader(ret))
+					ret, err = putImmutable(esmStorage, savePath, ret)
+					if err != nil {
+						logger.Errorf("storage.put(%s): %v", savePath, err)
+						return rex.Status(500, "Storage error, please try again")
+					}
 					// note: the source map is dropped
 					return ret
 				}
@@ -1518,11 +1532,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 			if !buildMeta.CJS && len(exports) > 0 {
 				moduleUrl += "?exports=" + strings.Join(exports, ",")
 			}
-			fmt.Fprintf(buf,
-				`export default function workerFactory(injectOrOptions) { const options = typeof injectOrOptions === "string" ? { inject: injectOrOptions }: injectOrOptions ?? {}; const { inject, name = "%s" } = options; const blob = new Blob(['import * as $module from "%s";', inject].filter(Boolean), { type: "application/javascript" }); return new Worker(URL.createObjectURL(blob), { type: "module", name })}`,
-				moduleUrl,
-				moduleUrl,
-			)
+			buf.WriteString(newWorkerFactory(moduleUrl))
 		} else {
 			if len(buildMeta.Imports) > 0 && !query.Has("exports") {
 				for _, dep := range buildMeta.Imports {
@@ -1566,22 +1576,6 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 	}
 }
 
-func getOrigin(ctx *rex.Context) string {
-	origin := ctx.R.Header.Get("X-Real-Origin")
-	if origin != "" {
-		return origin
-	}
-	proto := "http:"
-	if cfVisitor := ctx.R.Header.Get("CF-Visitor"); cfVisitor != "" {
-		if strings.Contains(cfVisitor, "\"https\"") {
-			proto = "https:"
-		}
-	} else if ctx.R.TLS != nil {
-		proto = "https:"
-	}
-	return proto + "//" + ctx.R.Host
-}
-
 func redirect(ctx *rex.Context, url string, isMovedPermanently bool) any {
 	code := http.StatusFound
 	if isMovedPermanently {
@@ -1604,6 +1598,16 @@ func errorJS(ctx *rex.Context, message string) any {
 	ctx.SetHeader("Content-Type", ctJavaScript)
 	ctx.SetHeader("Cache-Control", ccImmutable)
 	return buf.Bytes()
+}
+
+func newWorkerFactory(moduleUrl string) string {
+	urlLiteral := bytes.TrimSpace(utils.MustEncodeJSON(moduleUrl))
+	importLiteral := bytes.TrimSpace(utils.MustEncodeJSON(fmt.Sprintf("import * as $module from %s;", urlLiteral)))
+	return fmt.Sprintf(
+		`export default function workerFactory(injectOrOptions) { const moduleUrl = %s; const options = typeof injectOrOptions === "string" ? { inject: injectOrOptions }: injectOrOptions ?? {}; const { inject, name = moduleUrl } = options; const blob = new Blob([%s, inject].filter(Boolean), { type: "application/javascript" }); return new Worker(URL.createObjectURL(blob), { type: "module", name })}`,
+		urlLiteral,
+		importLiteral,
+	)
 }
 
 func getCSSEntryRedirectURL(origin string, esmPath EsmPath, cssEntry string) string {

--- a/server/router_test.go
+++ b/server/router_test.go
@@ -1,8 +1,218 @@
 package server
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
+
+	"github.com/esm-dev/esm.sh/internal/storage"
+	"github.com/ije/rex"
 )
+
+func TestWorkerFactoryEscapesModuleURL(t *testing.T) {
+	moduleUrl := "https://esm.sh\" } = options; globalThis.PWNED=1; const { z = \"\\\r\n\u2028\u2029"
+	code := newWorkerFactory(moduleUrl)
+
+	const urlPrefix = "const moduleUrl = "
+	start := strings.Index(code, urlPrefix)
+	if start < 0 {
+		t.Fatal("missing module URL")
+	}
+	start += len(urlPrefix)
+	end := strings.Index(code[start:], "; const options")
+	if end < 0 {
+		t.Fatal("invalid worker factory")
+	}
+	var gotUrl string
+	if err := json.Unmarshal([]byte(code[start:start+end]), &gotUrl); err != nil {
+		t.Fatal(err)
+	}
+	if gotUrl != moduleUrl {
+		t.Fatalf("module URL changed: %q", gotUrl)
+	}
+
+	const importPrefix = "const blob = new Blob(["
+	start = strings.Index(code, importPrefix)
+	if start < 0 {
+		t.Fatal("missing worker import")
+	}
+	start += len(importPrefix)
+	end = strings.Index(code[start:], ", inject]")
+	if end < 0 {
+		t.Fatal("invalid worker import")
+	}
+	var gotImport string
+	if err := json.Unmarshal([]byte(code[start:start+end]), &gotImport); err != nil {
+		t.Fatal(err)
+	}
+	urlLiteral, _ := json.Marshal(moduleUrl)
+	wantImport := "import * as $module from " + string(urlLiteral) + ";"
+	if gotImport != wantImport {
+		t.Fatalf("unexpected worker import %q", gotImport)
+	}
+}
+
+func TestJSONModuleRoute(t *testing.T) {
+	root := t.TempDir()
+	oldConfig := config
+	config = DefaultConfig()
+	config.WorkDir = root
+	defer func() {
+		config = oldConfig
+	}()
+
+	pkgDir := filepath.Join(root, "npm", "json-pkg@1.0.0", "node_modules", "json-pkg")
+	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	filename := filepath.Join(pkgDir, "payload.json")
+	if err := os.WriteFile(filename, []byte(`{};globalThis.PWNED=1`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fs, err := storage.NewFSStorage(filepath.Join(root, "storage"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := rex.New()
+	mux.Use(esmRouter(fs, nil))
+
+	request := func(ifNoneMatch string) *httptest.ResponseRecorder {
+		res := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/json-pkg@1.0.0/payload.json?module", nil)
+		if ifNoneMatch != "" {
+			req.Header.Set("If-None-Match", ifNoneMatch)
+		}
+		mux.ServeHTTP(res, req)
+		return res
+	}
+	stat, err := os.Stat(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	etag := fmt.Sprintf(`W/"%x-%x"`, stat.ModTime().Unix(), stat.Size())
+	res := request(etag)
+	if res.Code != http.StatusInternalServerError {
+		t.Fatalf("expected invalid JSON to return 500, got %d: %s", res.Code, res.Body)
+	}
+	if res.Header().Get("Cache-Control") != ccMustRevalidate {
+		t.Fatalf("invalid JSON must not be immutable: %q", res.Header().Get("Cache-Control"))
+	}
+	if res.Header().Get("Etag") != "" || res.Header().Get("Last-Modified") != "" {
+		t.Fatal("invalid JSON must not return cache validators")
+	}
+
+	if err := os.WriteFile(filename, []byte(`{"html":"</script>"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	res = request("")
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected valid JSON to return 200, got %d: %s", res.Code, res.Body)
+	}
+	if strings.Contains(res.Body.String(), "</script>") {
+		t.Fatalf("unsafe JSON module: %s", res.Body)
+	}
+	if res.Header().Get("Content-Length") != strconv.Itoa(res.Body.Len()) {
+		t.Fatalf("invalid Content-Length %q for %d-byte body", res.Header().Get("Content-Length"), res.Body.Len())
+	}
+}
+
+func TestIndexOriginIsConfigured(t *testing.T) {
+	t.Chdir("..")
+	cacheStore.Delete("index.html")
+	defer cacheStore.Delete("index.html")
+
+	oldConfig := config
+	config = DefaultConfig()
+	config.CdnOrigin = "https://cdn.example.com"
+	defer func() {
+		config = oldConfig
+	}()
+
+	fs, err := storage.NewFSStorage(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := rex.New()
+	mux.Use(esmRouter(fs, nil))
+	request := func(host string, poisoned bool) *httptest.ResponseRecorder {
+		res := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "http://"+host+"/", nil)
+		req.Header.Set("User-Agent", "Mozilla/5.0")
+		if poisoned {
+			req.Header.Set("X-Real-Origin", `https://esm.sh";globalThis.PWNED=1;"`)
+			req.Header.Set("CF-Visitor", `{"scheme":"https"}`)
+		}
+		mux.ServeHTTP(res, req)
+		return res
+	}
+
+	poisoned := request("attacker.invalid", true)
+	clean := request("honest.invalid", false)
+	if poisoned.Code != http.StatusOK || clean.Code != http.StatusOK {
+		t.Fatalf("unexpected index statuses %d and %d", poisoned.Code, clean.Code)
+	}
+	if !strings.HasPrefix(poisoned.Header().Get("Content-Type"), ctHTML) {
+		t.Fatalf("unexpected index content type %q", poisoned.Header().Get("Content-Type"))
+	}
+	if poisoned.Body.String() != clean.Body.String() {
+		t.Fatal("request headers changed the cached index")
+	}
+	if strings.Contains(clean.Body.String(), "attacker.invalid") || !strings.Contains(clean.Body.String(), config.CdnOrigin) {
+		t.Fatal("index did not use the configured origin")
+	}
+}
+
+func TestLegacyOriginIsConfigured(t *testing.T) {
+	oldConfig := config
+	config = DefaultConfig()
+	config.CdnOrigin = "https://cdn.example.com"
+	defer func() {
+		config = oldConfig
+	}()
+
+	fs, err := storage.NewFSStorage(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = fs.Put(
+		"legacy/v135/@types/react@19.2.5/index.d.ts",
+		strings.NewReader(`export * from "https://esm.sh/v135/react@19.2.5";`),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err = fs.Put(
+		"legacy/v135/react@19.0.0.meta",
+		strings.NewReader(`{"dts":"/v135/@types/react@latest/index.d.ts","code":"export default null"}`),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	mux := rex.New()
+	mux.Use(esmLegacyRouter(fs))
+	request := func(pathname string) *httptest.ResponseRecorder {
+		res := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "http://attacker.invalid"+pathname, nil)
+		req.Header.Set("X-Real-Origin", `https://esm.sh";globalThis.PWNED=1;"`)
+		req.Header.Set("CF-Visitor", `{"scheme":"https"}`)
+		mux.ServeHTTP(res, req)
+		return res
+	}
+
+	dts := request("/v135/@types/react@19.2.5/index.d.ts")
+	if dts.Code != http.StatusOK || strings.Contains(dts.Body.String(), "attacker.invalid") || !strings.Contains(dts.Body.String(), config.CdnOrigin+"/v135/") {
+		t.Fatalf("unexpected legacy d.ts response %d: %s", dts.Code, dts.Body)
+	}
+	entry := request("/v135/react@19.0.0")
+	if entry.Code != http.StatusOK || entry.Header().Get("X-TypeScript-Types") != config.CdnOrigin+"/v135/@types/react@latest/index.d.ts" {
+		t.Fatalf("unexpected legacy entry response %d, types %q", entry.Code, entry.Header().Get("X-TypeScript-Types"))
+	}
+}
 
 func TestCSSEntryRedirectURL(t *testing.T) {
 	origin := "https://esm.sh"

--- a/test/security-origin/test.ts
+++ b/test/security-origin/test.ts
@@ -1,0 +1,79 @@
+import { assert, assertEquals, assertStringIncludes } from "jsr:@std/assert";
+
+const attack = `https://esm.sh" } = options; globalThis.PWNED=1; const { z = "`;
+const headers = {
+  "x-real-origin": attack,
+  "cf-visitor": `{"scheme":"https"}`,
+};
+const browserHeaders = { "user-agent": "Mozilla/5.0" };
+
+Deno.test("request origin does not affect cacheable responses", async () => {
+  const workerUrl = "http://localhost:8080/xxhash-wasm@1.0.2?worker";
+  const poisonedWorker = await fetch(workerUrl, { headers }).then((res) =>
+    res.text()
+  );
+  const worker = await fetch(workerUrl).then((res) => res.text());
+  const otherHostWorker = await fetch(
+    workerUrl.replace("localhost", "127.0.0.1"),
+  ).then((res) => res.text());
+  assertEquals(poisonedWorker, worker);
+  assertEquals(otherHostWorker, worker);
+  assert(!worker.includes(attack));
+  assertStringIncludes(worker, `const moduleUrl = "http://localhost:8080/`);
+
+  const targetWorkerUrl =
+    "http://localhost:8080/xxhash-wasm@1.0.2/es2022/xxhash-wasm.mjs?worker";
+  const targetWorker = await fetch(targetWorkerUrl).then((res) => res.text());
+  const targetModuleUrl = targetWorkerUrl.replace("?worker", "");
+  const metaUrl =
+    "http://localhost:8080/xxhash-wasm@1.0.2?meta&target=es2022";
+  const moduleBefore = await fetch(targetModuleUrl).then((res) => res.text());
+  const metaBefore = await fetch(metaUrl).then((res) => res.text());
+  const poisonedTargetWorker = await fetch(targetWorkerUrl, { headers }).then(
+    (res) => res.text(),
+  );
+  assertEquals(poisonedTargetWorker, targetWorker);
+  assertEquals(
+    await fetch(targetModuleUrl, { headers }).then((res) => res.text()),
+    moduleBefore,
+  );
+  assertEquals(
+    await fetch(metaUrl, { headers }).then((res) => res.text()),
+    metaBefore,
+  );
+  assert(JSON.parse(metaBefore).integrity.startsWith("sha384-"));
+  assert(!targetWorker.includes(attack));
+  assertStringIncludes(
+    targetWorker,
+    `const moduleUrl = "http://localhost:8080/`,
+  );
+
+  const poisonedIndexRes = await fetch("http://localhost:8080/", {
+    headers: { ...browserHeaders, ...headers },
+  });
+  assertStringIncludes(
+    poisonedIndexRes.headers.get("content-type") ?? "",
+    "text/html",
+  );
+  const poisonedIndex = await poisonedIndexRes.text();
+  const index = await fetch("http://localhost:8080/", {
+    headers: browserHeaders,
+  }).then((res) => res.text());
+  assertEquals(poisonedIndex, index);
+  assert(!index.includes(attack));
+  assertStringIncludes(index, "A _no-build_ JavaScript CDN");
+
+  const entry = "http://localhost:8080/@octokit-next/types-rest-api@2.5.0";
+  const entryRes = await fetch(entry, { headers });
+  entryRes.body?.cancel();
+  const dtsUrl = entryRes.headers.get("x-typescript-types");
+  assert(dtsUrl);
+  assertEquals(dtsUrl, `${entry}/index.d.ts`);
+  const poisonedDts = await fetch(dtsUrl, { headers }).then((res) =>
+    res.text()
+  );
+  const dts = await fetch(dtsUrl).then((res) => res.text());
+  assertEquals(poisonedDts, dts);
+  assert(!dts.includes(attack));
+  assertStringIncludes(dts, "http://localhost:8080/");
+});


### PR DESCRIPTION
## Summary

- Harden origin and host validation across server routing and build configuration.
- Update filesystem and S3 storage handling to enforce safer request and artifact boundaries.
- Add regression coverage for security-origin behavior and related routing, configuration, and build paths.
- Document the configuration changes and update the example config.

## Testing

- Added and updated Go unit tests covering storage, routing, configuration, path handling, and build behavior.
- Added Deno integration coverage for security-origin requests.
- Not run (not requested).