### PR TITLE
Configure a trusted CDN origin for generated URLs

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -73,6 +73,7 @@ docker run -p 80:80 ghcr.io/esm-dev/esm.sh:latest
 
 Available environment variables:
 
+- `CDN_ORIGIN`: The public CDN origin, default is empty (use the request origin).
 - `COMPRESS`: Compress http responses with gzip/brotli, default is `true`.
 - `CUSTOM_LANDING_PAGE_ORIGIN`: The custom landing page origin, default is empty.
 - `CUSTOM_LANDING_PAGE_ASSETS`: The custom landing page assets separated by comma(,), default is empty.

--- a/HOSTING.md
+++ b/HOSTING.md
@@ -68,7 +68,7 @@ docker pull ghcr.io/esm-dev/esm.sh:dev    # latest dev version
 Run the container:
 
 ```bash
-docker run -p 80:80 ghcr.io/esm-dev/esm.sh:latest
+docker run -e CDN_ORIGIN=https://cdn.example.com -p 80:80 ghcr.io/esm-dev/esm.sh:latest
 ```
 
 Available environment variables:

--- a/config.example.jsonc
+++ b/config.example.jsonc
@@ -7,6 +7,9 @@
   // Note: if you are running the server in a docker container, you need to expose port `443:443`.
   "tlsPort": 0,
 
+  // The public CDN origin, default is empty (use `http.Request.Host` as the origin).
+  "cdnOrigin": "",
+
   // Allowed CORS origins, default is allow all origins.
   // Note: A valid origin must be a valid URL, including the protocol, domain, and port. e.g. "https://example.com".
   "corsAllowOrigins": [],

--- a/server/config.go
+++ b/server/config.go
@@ -27,6 +27,7 @@ var (
 type Config struct {
 	Port                uint16                       `json:"port"`
 	TlsPort             uint16                       `json:"tlsPort"`
+	CdnOrigin           string                       `json:"cdnOrigin"`
 	CustomLandingPage   LandingPageOptions           `json:"customLandingPage"`
 	WorkDir             string                       `json:"workDir"`
 	CorsAllowOrigins    []string                     `json:"corsAllowOrigins"`
@@ -114,6 +115,18 @@ func DefaultConfig() *Config {
 func normalizeConfig(config *Config) {
 	if config.Port == 0 {
 		config.Port = 80
+	}
+	if config.CdnOrigin == "" {
+		config.CdnOrigin = os.Getenv("CDN_ORIGIN")
+	}
+	if origin := config.CdnOrigin; origin != "" {
+		u, err := url.Parse(origin)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			fmt.Println(term.Red("[error] invalid cdn origin: " + origin))
+			config.CdnOrigin = ""
+		} else {
+			config.CdnOrigin = u.Scheme + "://" + u.Host
+		}
 	}
 	if config.WorkDir == "" {
 		if v := os.Getenv("ESMDIR"); v != "" && existsDir(v) {

--- a/server/router.go
+++ b/server/router.go
@@ -1567,9 +1567,8 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) rex.Handle {
 }
 
 func getOrigin(ctx *rex.Context) string {
-	origin := ctx.R.Header.Get("X-Real-Origin")
-	if origin != "" {
-		return origin
+	if config.CdnOrigin != "" {
+		return config.CdnOrigin
 	}
 	proto := "http:"
 	if cfVisitor := ctx.R.Header.Get("CF-Visitor"); cfVisitor != "" {

--- a/test/origin/test.ts
+++ b/test/origin/test.ts
@@ -1,0 +1,59 @@
+import { assert, assertEquals, assertStringIncludes } from "jsr:@std/assert";
+
+const poison =
+  `https://attacker.invalid" } = options; globalThis.PWNED = true; const { z = "`;
+
+Deno.test("landing page ignores X-Real-Origin", async () => {
+  const poisoned = await fetch("http://localhost:8080/", {
+    headers: {
+      "User-Agent": "Mozilla/5.0",
+      "X-Real-Origin": poison,
+    },
+  });
+  const poisonedHtml = await poisoned.text();
+  assertEquals(poisoned.status, 200);
+  assertStringIncludes(poisonedHtml, "http://localhost:8080/PKG");
+  assert(!poisonedHtml.includes("attacker.invalid"));
+  assert(!poisonedHtml.includes("globalThis.PWNED"));
+
+  const honestHtml = await fetch("http://localhost:8080/", {
+    headers: {
+      "User-Agent": "Mozilla/5.0",
+    },
+  }).then((res) => res.text());
+  assertEquals(honestHtml, poisonedHtml);
+});
+
+Deno.test("WASM module wrapper ignores X-Real-Origin", async () => {
+  const res = await fetch(
+    "http://localhost:8080/esm-compiler@0.7.2/pkg/esm_compiler_bg.wasm?module&origin-regression",
+    {
+      headers: {
+        "X-Real-Origin": poison,
+      },
+    },
+  );
+  const code = await res.text();
+  assertEquals(res.status, 200);
+  assertStringIncludes(
+    code,
+    `fetch("http://localhost:8080/esm-compiler@0.7.2/pkg/esm_compiler_bg.wasm")`,
+  );
+  assert(!code.includes("attacker.invalid"));
+  assert(!code.includes("globalThis.PWNED"));
+});
+
+Deno.test("redirects ignore X-Real-Origin", async () => {
+  const res = await fetch("http://localhost:8080/react@^18.3.1/package.json", {
+    redirect: "manual",
+    headers: {
+      "X-Real-Origin": poison,
+    },
+  });
+  const location = res.headers.get("location");
+  res.body?.cancel();
+  assertEquals(res.status, 302);
+  assert(location);
+  assert(location.startsWith("http://localhost:8080/react@18."));
+  assert(!location.includes("attacker.invalid"));
+});


### PR DESCRIPTION
- Add configurable `CDN_ORIGIN`/`cdnOrigin` support with URL validation.
- Stop trusting `X-Real-Origin` when generating CDN URLs and redirects.
- Add regression tests covering landing pages, WASM wrappers, and redirects.