### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /cli/npm
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This adds a `.github/dependabot.yml` covering the four ecosystems in the
repo — `gomod` (`/`), `npm` (`/cli/npm`), `docker` (`/`), and
`github-actions` (`/`) — on a weekly schedule, with updates grouped into a
single PR per ecosystem to keep noise low.

Grouping means at most a handful of PRs a week in the worst case, and none
in quiet weeks. If the npm entry ends up self-referential noise (the CLI
package publishes this repo's own binaries), dropping that block is a
two-line change — happy to adjust.

---
This change was generated by [Autar](https://autar.ai) and reviewed by a
human before submission.
