### PR TITLE
Fix source map export analysis

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -291,6 +291,9 @@ func (ctx *BuildContext) buildModule(analyzeMode bool) (meta *BuildMeta, include
 		meta = &BuildMeta{CSSEntry: entry.main}
 		return
 	}
+	if analyzeMode && strings.HasSuffix(entry.main, ".map") {
+		return
+	}
 
 	// json module
 	if strings.HasSuffix(entry.main, ".json") {

--- a/test/issue-1388/test.ts
+++ b/test/issue-1388/test.ts
@@ -1,0 +1,14 @@
+import { assertEquals } from "jsr:@std/assert";
+
+Deno.test("issue #1388 - ignore source map exports during analysis", async () => {
+  const res = await fetch(
+    "http://localhost:8080/vanilla-jsoneditor@3.13.0/standalone.js",
+    { headers: { "User-Agent": "i'm a browser" } },
+  );
+
+  assertEquals(res.status, 200);
+  assertEquals(
+    res.headers.get("content-type"),
+    "application/javascript; charset=utf-8",
+  );
+});

--- a/test/issue-1388/test.ts
+++ b/test/issue-1388/test.ts
@@ -5,6 +5,7 @@ Deno.test("issue #1388 - ignore source map exports during analysis", async () =>
     "http://localhost:8080/vanilla-jsoneditor@3.13.0/standalone.js",
     { headers: { "User-Agent": "i'm a browser" } },
   );
+  await res.body?.cancel();
 
   assertEquals(res.status, 200);
   assertEquals(


### PR DESCRIPTION
Skip resolved .map files during splitting analysis so source-map exports are not passed to esbuild.

Close #1388