### PR TITLE
Invalidate stale latest resolution when a newer explicit version is requested

### DIFF
--- a/server/cache.go
+++ b/server/cache.go
@@ -41,6 +41,10 @@ func setCacheItem(key string, data any, cacheTtl time.Duration) {
 	cacheStore.Store(key, &cacheItem{exp.UnixMilli(), data})
 }
 
+func deleteCacheItem(key string) {
+	cacheStore.Delete(key)
+}
+
 func withCache[T any](key string, cacheTtl time.Duration, fetch func() (data T, aliasKey string, err error)) (data T, err error) {
 	if cacheTtl == 0 {
 		data, _, err = fetch()

--- a/server/npmrc.go
+++ b/server/npmrc.go
@@ -249,7 +249,7 @@ func (npmrc *NpmRC) getPackageInfoContext(ctx context.Context, pkgName string, v
 	}
 
 	ttl := time.Duration(config.NpmQueryCacheTTL) * time.Second
-	pkg, err := withCache("npm:"+pkgName+"@"+version, ttl, func() (*npm.PackageJSON, string, error) {
+	return withCache("npm:"+pkgName+"@"+version, ttl, func() (*npm.PackageJSON, string, error) {
 		if npm.IsExactVersion(version) {
 			var raw npm.PackageJSONRaw
 			pkgJsonPath := filepath.Join(npmrc.StoreDir(), pkgName+"@"+version, "node_modules", pkgName, "package.json")
@@ -282,20 +282,20 @@ func (npmrc *NpmRC) getPackageInfoContext(ctx context.Context, pkgName string, v
 
 		return rawData.ToNpmPackage(), "npm:" + pkgName + "@" + rawData.Version, nil
 	})
-	if err == nil && npm.IsExactVersion(version) {
-		invalidateDistTagCacheIfNewer(pkgName, pkg.Version)
-	}
-	return pkg, err
 }
 
 // invalidateDistTagCacheIfNewer invalidates the cached "latest" (and its 404
-// counterpart) resolution of a package when an explicitly-requested version
-// resolves to a version newer than the currently cached one. This lets package
-// authors refresh the default (bare-name) version immediately by requesting the
-// new version explicitly, without waiting for the npm query cache TTL to expire.
-// In turn, that allows deployments to run with a larger npmQueryCacheTTL while
-// still picking up new releases promptly when the author asks for one.
+// counterpart) resolution of a package when a newer explicit version has just
+// been built successfully. It should only be called after the build of the
+// requested version has succeeded, so the default (bare-name) URL can follow the
+// new version immediately without waiting for the npm query cache TTL to expire.
+// Calling it at package-resolution time would let repeated explicit-version
+// requests force continuous npm re-queries, and could point the default URL at a
+// version whose build actually fails. This pairs well with a larger
+// npmQueryCacheTTL: authors refresh on demand, so the server can query the
+// registry less often.
 func invalidateDistTagCacheIfNewer(pkgName string, version string) {
+	version = npm.NormalizePackageVersion(version)
 	if !npm.IsExactVersion(version) {
 		return
 	}

--- a/server/npmrc.go
+++ b/server/npmrc.go
@@ -284,30 +284,24 @@ func (npmrc *NpmRC) getPackageInfoContext(ctx context.Context, pkgName string, v
 	})
 }
 
-// invalidateDistTagCacheIfNewer invalidates the cached "latest" (and its 404
-// counterpart) resolution of a package when a newer explicit version has just
-// been built successfully. It should only be called after the build of the
-// requested version has succeeded, so the default (bare-name) URL can follow the
-// new version immediately without waiting for the npm query cache TTL to expire.
-// Calling it at package-resolution time would let repeated explicit-version
-// requests force continuous npm re-queries, and could point the default URL at a
-// version whose build actually fails. This pairs well with a larger
-// npmQueryCacheTTL: authors refresh on demand, so the server can query the
-// registry less often.
+// invalidateDistTagCacheIfNewer drops the cached "latest" (and its 404)
+// resolution of pkgName once a newer exact version has been built
+// successfully, so the default (bare-name) URL follows it without waiting for
+// the npm query cache TTL. Only call it after a build succeeds: replaying it
+// at resolution time would keep forcing npm re-queries and could pin the
+// default URL to a version whose build fails.
 func invalidateDistTagCacheIfNewer(pkgName string, version string) {
 	version = npm.NormalizePackageVersion(version)
 	if !npm.IsExactVersion(version) {
 		return
 	}
-	v, ok := getCacheItem("npm:" + pkgName + "@latest")
-	if !ok {
-		return
-	}
+	key := "npm:" + pkgName + "@latest"
+	v, ok := getCacheItem(key)
 	latest, ok := v.(*npm.PackageJSON)
-	if !ok || latest.Version == version || !semverLessThan(latest.Version, version) {
+	if !ok || !semverLessThan(latest.Version, version) {
 		return
 	}
-	deleteCacheItem("npm:" + pkgName + "@latest")
+	deleteCacheItem(key)
 	deleteCacheItem("404:" + pkgName + "@latest")
 }
 

--- a/server/npmrc.go
+++ b/server/npmrc.go
@@ -249,7 +249,7 @@ func (npmrc *NpmRC) getPackageInfoContext(ctx context.Context, pkgName string, v
 	}
 
 	ttl := time.Duration(config.NpmQueryCacheTTL) * time.Second
-	return withCache("npm:"+pkgName+"@"+version, ttl, func() (*npm.PackageJSON, string, error) {
+	pkg, err := withCache("npm:"+pkgName+"@"+version, ttl, func() (*npm.PackageJSON, string, error) {
 		if npm.IsExactVersion(version) {
 			var raw npm.PackageJSONRaw
 			pkgJsonPath := filepath.Join(npmrc.StoreDir(), pkgName+"@"+version, "node_modules", pkgName, "package.json")
@@ -282,6 +282,33 @@ func (npmrc *NpmRC) getPackageInfoContext(ctx context.Context, pkgName string, v
 
 		return rawData.ToNpmPackage(), "npm:" + pkgName + "@" + rawData.Version, nil
 	})
+	if err == nil && npm.IsExactVersion(version) {
+		invalidateDistTagCacheIfNewer(pkgName, pkg.Version)
+	}
+	return pkg, err
+}
+
+// invalidateDistTagCacheIfNewer invalidates the cached "latest" (and its 404
+// counterpart) resolution of a package when an explicitly-requested version
+// resolves to a version newer than the currently cached one. This lets package
+// authors refresh the default (bare-name) version immediately by requesting the
+// new version explicitly, without waiting for the npm query cache TTL to expire.
+// In turn, that allows deployments to run with a larger npmQueryCacheTTL while
+// still picking up new releases promptly when the author asks for one.
+func invalidateDistTagCacheIfNewer(pkgName string, version string) {
+	if !npm.IsExactVersion(version) {
+		return
+	}
+	v, ok := getCacheItem("npm:" + pkgName + "@latest")
+	if !ok {
+		return
+	}
+	latest, ok := v.(*npm.PackageJSON)
+	if !ok || latest.Version == version || !semverLessThan(latest.Version, version) {
+		return
+	}
+	deleteCacheItem("npm:" + pkgName + "@latest")
+	deleteCacheItem("404:" + pkgName + "@latest")
 }
 
 func (npmrc *NpmRC) getPackageInfoByDate(pkgName string, targetDate time.Time) (packageJson *npm.PackageJSON, err error) {

--- a/server/npmrc_test.go
+++ b/server/npmrc_test.go
@@ -20,48 +20,24 @@ import (
 )
 
 func TestInvalidateDistTagCacheIfNewer(t *testing.T) {
-	// An explicit-version request that is NOT newer than the cached `latest`
-	// resolution must leave the caches untouched.
-	setCacheItem("npm:cache-test@latest", &npm.PackageJSON{Version: "1.2.0"}, time.Minute)
-	setCacheItem("404:cache-test@latest", "boom", time.Minute)
-	invalidateDistTagCacheIfNewer("cache-test", "1.2.0")
-	if _, ok := getCacheItem("npm:cache-test@latest"); !ok {
-		t.Fatal("expected latest cache to be preserved when the requested version equals the cached one")
+	tests := []struct {
+		request string
+		invalid bool
+	}{
+		{"1.2.0", false},  // equal to the cached `latest`
+		{"1.1.0", false},  // older
+		{"2.0.0", true},   // newer
+		{"latest", false}, // non-exact
+		{"v2.0.0", true},  // v-prefixed newer
 	}
-	if _, ok := getCacheItem("404:cache-test@latest"); !ok {
-		t.Fatal("expected 404 cache to be preserved when the requested version equals the cached one")
-	}
-
-	// An older explicit-version request must not invalidate either.
-	invalidateDistTagCacheIfNewer("cache-test", "1.1.0")
-	if _, ok := getCacheItem("npm:cache-test@latest"); !ok {
-		t.Fatal("expected latest cache to be preserved when the requested version is older")
-	}
-	if _, ok := getCacheItem("404:cache-test@latest"); !ok {
-		t.Fatal("expected 404 cache to be preserved when the requested version is older")
-	}
-
-	// A newer explicit-version request invalidates both the `latest` and its 404 cache.
-	invalidateDistTagCacheIfNewer("cache-test", "2.0.0")
-	if _, ok := getCacheItem("npm:cache-test@latest"); ok {
-		t.Fatal("expected latest cache to be invalidated when a newer version is requested")
-	}
-	if _, ok := getCacheItem("404:cache-test@latest"); ok {
-		t.Fatal("expected 404 cache to be invalidated when a newer version is requested")
-	}
-
-	// Non-exact versions are never acted upon.
-	setCacheItem("npm:cache-test@latest", &npm.PackageJSON{Version: "1.0.0"}, time.Minute)
-	invalidateDistTagCacheIfNewer("cache-test", "latest")
-	if _, ok := getCacheItem("npm:cache-test@latest"); !ok {
-		t.Fatal("expected latest cache to be preserved for a non-exact version")
-	}
-
-	// A `v`-prefixed version is normalized and still acted upon.
-	setCacheItem("npm:cache-test@latest", &npm.PackageJSON{Version: "1.0.0"}, time.Minute)
-	invalidateDistTagCacheIfNewer("cache-test", "v2.0.0")
-	if _, ok := getCacheItem("npm:cache-test@latest"); ok {
-		t.Fatal("expected latest cache to be invalidated for a v-prefixed newer version")
+	for _, test := range tests {
+		setCacheItem("npm:cache-test@latest", &npm.PackageJSON{Version: "1.2.0"}, time.Minute)
+		setCacheItem("404:cache-test@latest", "boom", time.Minute)
+		invalidateDistTagCacheIfNewer("cache-test", test.request)
+		_, ok := getCacheItem("npm:cache-test@latest")
+		if invalid := !ok; invalid != test.invalid {
+			t.Fatalf("request %q: expected invalidated=%v, got %v", test.request, test.invalid, invalid)
+		}
 	}
 }
 

--- a/server/npmrc_test.go
+++ b/server/npmrc_test.go
@@ -14,7 +14,49 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/esm-dev/esm.sh/internal/npm"
 )
+
+func TestInvalidateDistTagCacheIfNewer(t *testing.T) {
+	// An explicit-version request that is NOT newer than the cached `latest`
+	// resolution must leave the caches untouched.
+	setCacheItem("npm:cache-test@latest", &npm.PackageJSON{Version: "1.2.0"}, time.Minute)
+	setCacheItem("404:cache-test@latest", "boom", time.Minute)
+	invalidateDistTagCacheIfNewer("cache-test", "1.2.0")
+	if _, ok := getCacheItem("npm:cache-test@latest"); !ok {
+		t.Fatal("expected latest cache to be preserved when the requested version equals the cached one")
+	}
+	if _, ok := getCacheItem("404:cache-test@latest"); !ok {
+		t.Fatal("expected 404 cache to be preserved when the requested version equals the cached one")
+	}
+
+	// An older explicit-version request must not invalidate either.
+	invalidateDistTagCacheIfNewer("cache-test", "1.1.0")
+	if _, ok := getCacheItem("npm:cache-test@latest"); !ok {
+		t.Fatal("expected latest cache to be preserved when the requested version is older")
+	}
+	if _, ok := getCacheItem("404:cache-test@latest"); !ok {
+		t.Fatal("expected 404 cache to be preserved when the requested version is older")
+	}
+
+	// A newer explicit-version request invalidates both the `latest` and its 404 cache.
+	invalidateDistTagCacheIfNewer("cache-test", "2.0.0")
+	if _, ok := getCacheItem("npm:cache-test@latest"); ok {
+		t.Fatal("expected latest cache to be invalidated when a newer version is requested")
+	}
+	if _, ok := getCacheItem("404:cache-test@latest"); ok {
+		t.Fatal("expected 404 cache to be invalidated when a newer version is requested")
+	}
+
+	// Non-exact versions are never acted upon.
+	setCacheItem("npm:cache-test@latest", &npm.PackageJSON{Version: "1.0.0"}, time.Minute)
+	invalidateDistTagCacheIfNewer("cache-test", "latest")
+	if _, ok := getCacheItem("npm:cache-test@latest"); !ok {
+		t.Fatal("expected latest cache to be preserved for a non-exact version")
+	}
+}
 
 func TestSameURLOrigin(t *testing.T) {
 	registryUrl, _ := url.Parse("https://registry.example/package")

--- a/server/npmrc_test.go
+++ b/server/npmrc_test.go
@@ -56,6 +56,13 @@ func TestInvalidateDistTagCacheIfNewer(t *testing.T) {
 	if _, ok := getCacheItem("npm:cache-test@latest"); !ok {
 		t.Fatal("expected latest cache to be preserved for a non-exact version")
 	}
+
+	// A `v`-prefixed version is normalized and still acted upon.
+	setCacheItem("npm:cache-test@latest", &npm.PackageJSON{Version: "1.0.0"}, time.Minute)
+	invalidateDistTagCacheIfNewer("cache-test", "v2.0.0")
+	if _, ok := getCacheItem("npm:cache-test@latest"); ok {
+		t.Fatal("expected latest cache to be invalidated for a v-prefixed newer version")
+	}
 }
 
 func TestSameURLOrigin(t *testing.T) {

--- a/server/router.go
+++ b/server/router.go
@@ -1378,9 +1378,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) http.Handler {
 					return
 				}
 				buildMeta = output.meta
-				// A new version has just been built successfully: let the default
-				// (bare-name) URL follow it immediately instead of waiting for the
-				// npm query cache TTL to expire.
+				// Follow a freshly built version in the default URL immediately.
 				invalidateDistTagCacheIfNewer(esmPath.PkgName, esmPath.PkgVersion)
 			case <-time.After(time.Duration(config.BuildWaitTime) * time.Second):
 				header.Set("Cache-Control", ccMustRevalidate)

--- a/server/router.go
+++ b/server/router.go
@@ -1378,6 +1378,10 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) http.Handler {
 					return
 				}
 				buildMeta = output.meta
+				// A new version has just been built successfully: let the default
+				// (bare-name) URL follow it immediately instead of waiting for the
+				// npm query cache TTL to expire.
+				invalidateDistTagCacheIfNewer(esmPath.PkgName, esmPath.PkgVersion)
 			case <-time.After(time.Duration(config.BuildWaitTime) * time.Second):
 				header.Set("Cache-Control", ccMustRevalidate)
 				writeStatus(w, http.StatusRequestTimeout, "timeout, the module is waiting to be built, please try refreshing the page.")


### PR DESCRIPTION
## Problem

After publishing a new version, the default (bare-name) URL such as `https://esm.sh/<pkg>/...` keeps resolving to the previously cached `latest` version until the npm query cache TTL (`npmQueryCacheTTL`, default 600s) expires. Requesting the new version explicitly (`<pkg>@newver/...`) builds and caches it, but does not make the default URL follow — the two resolutions live in separate cache entries (`npm:<pkg>@latest` vs `npm:<pkg>@<version>`).

## Change

When an explicit-version request has been **built successfully**, and that version is newer than the currently cached `latest` resolution, invalidate the `npm:<pkg>@latest` and `404:<pkg>@latest` cache entries. The invalidation is triggered from the build-success path in the router (`invalidateDistTagCacheIfNewer`), and the next bare-name request re-resolves the dist-tag through the registry version route (a single small `package.json`, not the full metadata), so it still follows npm's official `latest` dist-tag — no guessing involved.

Two design choices worth noting:

- **Invalidation happens only on build success, not at package-resolution time.** Doing it at resolution time would let repeated explicit-version requests continuously force npm re-queries (the invalidation runs even on cache hits), and could point the default URL at a version whose build actually fails. Since a built version is cached and not rebuilt, a successful build invalidates at most once per version — it cannot be replayed to keep forcing registry queries.
- Requests for an equal or older version, or non-exact specifiers (including `latest` itself), never touch the cache. A `v`/`=`-prefixed version is normalized first.

## Benefits

- **Instant follow for package authors**: right after publishing, request the new version explicitly once and the default URL picks it up immediately instead of waiting out the TTL.
- **Allows a larger `npmQueryCacheTTL`**: since authors can refresh on demand, deployments can raise `npmQueryCacheTTL` (e.g. to 1h) to reduce registry query pressure without delaying how soon new releases become the default.

## Tests

Added `TestInvalidateDistTagCacheIfNewer` covering equal, older, newer, non-exact and `v`-prefixed version requests.