### PR TITLE
Fix sub-module duplication for packages with a sideEffects field

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -170,12 +170,9 @@ func (ctx *BuildContext) Build(buildCtx context.Context) (meta *BuildMeta, err e
 	}
 
 	// analyze splitting modules if bundling
-	if ctx.pkgJson.Exports.Len() > 1 && ctx.shouldBundle() {
+	if ctx.pkgJson.Exports.Len() > 1 && (ctx.shouldBundle() || ctx.shouldBundleInternalModules()) {
 		ctx.status = "analyze"
-		err = ctx.analyzeSplitting()
-		if err != nil {
-			return
-		}
+		ctx.analyzeSplitting()
 	}
 
 	// build the module
@@ -806,7 +803,7 @@ func (ctx *BuildContext) buildModule(analyzeMode bool) (meta *BuildMeta, include
 						// - it's not a dynamic import and the `?bundle=false` flag is not present
 						// - it's not in the `splitting` list
 						isDynamicImport := args.Kind == esbuild.ResolveJSDynamicImport
-						bundleInternalModule := exportAs == "" && !isDynamicImport && ctx.bundleMode != BundleFalse && ctx.pkgJson.Type == "module"
+						bundleInternalModule := exportAs == "" && !isDynamicImport && ctx.shouldBundleInternalModules()
 						if modulePath == entry.main || exportAs == entrySpecifier || (!isDynamicImport && !noBundle) || bundleInternalModule {
 							if existsFile(resolvedFilename) {
 								pkgDir := path.Join(ctx.wd, "node_modules", pkgName)
@@ -1653,6 +1650,12 @@ func (ctx *BuildContext) install() (err error) {
 		return
 	}
 	return
+}
+
+// internal modules of an ESM package are bundled into every entry point even when `shouldBundle`
+// is false, so the analysis must run for them, or module-level state is duplicated per entry.
+func (ctx *BuildContext) shouldBundleInternalModules() bool {
+	return ctx.bundleMode != BundleFalse && ctx.pkgJson.Type == "module"
 }
 
 func (ctx *BuildContext) shouldBundle() bool {

--- a/server/build_analyzer.go
+++ b/server/build_analyzer.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"os"
 	"path"
@@ -18,7 +17,7 @@ type Ref struct {
 	importers *set.Set[string]
 }
 
-func (ctx *BuildContext) analyzeSplitting() (err error) {
+func (ctx *BuildContext) analyzeSplitting() {
 	exportNames := set.New[string]()
 
 	for _, exportName := range ctx.pkgJson.Exports.Keys() {
@@ -145,10 +144,12 @@ func (ctx *BuildContext) analyzeSplitting() (err error) {
 			}
 			_, includes, err := b.buildModule(true)
 			if err != nil {
-				if err.Error() == "could not resolve build entry" {
-					continue // ignore non-existent exports
+				// splitting is an optimization, so ignore an export that can't be analyzed,
+				// like an asset esbuild has no loader for
+				if err.Error() != "could not resolve build entry" {
+					ctx.logger.Warnf("build(%s): failed to analyze %s: %v", ctx.esmPath.String(), esmPath.String(), err)
 				}
-				return fmt.Errorf("failed to analyze %s: %v", esmPath.String(), err)
+				continue
 			}
 			for _, include := range includes {
 				module, importer := include[0], include[1]
@@ -205,6 +206,4 @@ func (ctx *BuildContext) analyzeSplitting() (err error) {
 			}
 		}
 	}
-
-	return
 }

--- a/test/splitting/splitting.test.ts
+++ b/test/splitting/splitting.test.ts
@@ -1,7 +1,19 @@
-import { assertStringIncludes } from "jsr:@std/assert";
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert";
+
+// `temporal-polyfill` has a non-empty `sideEffects` field, so its sub-modules are not bundled.
+// `getAny` writes to a module-level WeakMap that `withCalendar` reads back. Two copies of that
+// module mean two maps, and the read then throws `Invalid calling context`.
+import * as PlainDateFns from "http://localhost:8080/temporal-polyfill@1.0.4/fns/PlainDate?target=es2022";
+import { getAny } from "http://localhost:8080/temporal-polyfill@1.0.4/fns/Calendar?target=es2022";
 
 Deno.test("splitting sub-modules are shared by export modules", async () => {
   const res = await fetch("http://localhost:8080/svelte@5.16.0?target=es2022");
   const text = await res.text();
   assertStringIncludes(text, "src/internal/client/render.mjs");
+});
+
+Deno.test("splitting sub-modules are shared by packages with a `sideEffects` field", () => {
+  const date = PlainDateFns.create(2026, 9, 6);
+  const withCalendar = PlainDateFns.withCalendar(date, getAny("iso8601"));
+  assertEquals(PlainDateFns.toString(withCalendar), "2026-09-06");
 });


### PR DESCRIPTION
Two entry points of the same package can each get their own copy of a shared internal module, so any module-level state in it exists twice.

Here is a published package it breaks. One import, and the first call throws:

```js
import * as dm from "https://esm.sh/daymath@0.7.3";
dm.parse("2026-09-06");
// TypeError: Invalid calling context
```

`daymath` imports five `temporal-polyfill/fns/*` subpaths.  esm.sh builds each subpath as its own entry point and inlines `chunks/funcApi.js` into every one, so the `WeakMap` that file holds exists once per entry.  daymath passes `getAny` from `fns/Calendar` into `fromString` from `fns/PlainDate`, so the resolver registers its calendar record in one entry's map while the other entry reads a different one, and the brand check fails.  You can see the duplication without running anything:

```sh
curl -s https://esm.sh/temporal-polyfill@1.0.4/es2022/fns/PlainDate.mjs | grep -c 'chunks/'
curl -s https://esm.sh/temporal-polyfill@1.0.4/es2022/fns/Calendar.mjs | grep -c 'chunks/'
```

Both print `0`.  Neither entry imports a shared chunk, so each one carries its own copy.

The cause is two conditions that answer the same question and disagree.  `shouldBundle()` returns false when a package sets a non-empty `sideEffects` field, so `analyzeSplitting()` never runs and `ctx.splitting` stays nil.  But `bundleInternalModule` in `buildModule` does not consult `shouldBundle()`.  Its package level test is just `bundleMode != BundleFalse && pkgJson.Type == "module"`.  So internal modules still get inlined into every entry point, with nothing left to de-duplicate them.  `temporal-polyfill` sets `sideEffects` to a four element array, so it lands in that gap.

That gap opened in #1367, which added `bundleInternalModule` for `?standalone`.  The condition is wider than standalone mode, so it reaches plain requests too.

The fix pulls the package level part of that condition into `shouldBundleInternalModules()` and calls it from both places.  Now the analysis runs exactly when internal bundling can happen, and the two conditions cannot drift apart again.

This also lines the code up with what the README already promises.  It says esm.sh bundles sub-modules "that are not shared by entry modules defined in the `exports` field", with no `sideEffects` exception, and it warns that repeated bundling of shared modules "can break package side effects".  That is exactly the failure above.

`@angular/common@20.1.4` is a second package this repairs, independent of the test case.  Its `fesm2022` entries share five modules.

The second hunk is a prerequisite rather than a drive by.  Running the analysis on more packages exposed a latent problem in it.  `analyzeSplitting()` filters exports by extension, listing `.json`, `.css`, `.wasm`, and the `.d.*` forms, but it misses `.scss`.  `@uppy/dashboard@5.1.0` exports `./css/style.scss`, esbuild has no loader for it, and the old code returned that error and failed the whole build.  `@uppy/dashboard` is already in the suite at `test/import-json`, so the gate change alone turns that test red.

Skipping the export instead of failing is also better than the old behaviour on its own.  The `defer` that writes `splitting.txt` is registered before the analysis loop, so it ran on the old error path too and wrote an empty result.  One unanalyzable export both failed the build and poisoned the cache for that package version.  The new code caches a partial result and logs a warning, and I kept the existing `could not resolve build entry` case silent so log volume does not change for the common phantom export.

Two things worth flagging:

`analyzeSplitting()` can no longer return a non nil error, so I dropped the result and the caller's check rather than leave a dead branch.  `go vet` does not catch that one.  Happy to put the signature back if you would rather keep it for future use.

Cached builds keep their old output, since the build path carries no version component.  A package built before the deploy still serves its inlined copies until something invalidates it.  That mixed state is never worse than today, it is one shared copy plus the stale inlined ones instead of one per entry, so I did not add a version bump.  That call felt like yours to make.

Adds a case to `test/splitting`.  It fails with `Invalid calling context` on `main` and passes with this change.

Tested with Go 1.26.8 and Deno 2.7.14, and the four directories the change touches also pass on Deno 1.46.3.  `test/gh` times out locally on `gh/streamlit/streamlit@1.34.0` on `main` as well, so I skipped that one, everything else passes.


