### PR TITLE
Simplify build queue scheduling and shared results

### DIFF
--- a/internal/importmap/importmap_test.go
+++ b/internal/importmap/importmap_test.go
@@ -108,7 +108,10 @@ func TestAddPackages(t *testing.T) {
 
 func TestResolve(t *testing.T) {
 	im := Blank()
-	im.AddImportFromSpecifier("react-dom@19/client", false)
+	_, errors := im.AddImportFromSpecifier("react-dom@19.2.4/client", false)
+	if len(errors) > 0 {
+		t.Fatalf("Failed to add react-dom/client: %v", errors)
+	}
 	referrer, _ := url.Parse("file:///main.js")
 	modUrl, ok := im.Resolve("react", referrer)
 	if !ok {

--- a/server/build.go
+++ b/server/build.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync/atomic"
 
 	"github.com/esm-dev/esm.sh/internal/npm"
 	"github.com/esm-dev/esm.sh/internal/npm_replacements"
@@ -48,8 +49,7 @@ type BuildContext struct {
 	wd          string
 	pkgJson     *npm.PackageJSON
 	path        string
-	rawPath     string
-	status      string
+	status      atomic.Value
 	splitting   *set.ReadOnlySet[string]
 	esmImports  [][2]string
 	cjsRequires [][3]string
@@ -154,7 +154,7 @@ func (ctx *BuildContext) Build(buildCtx context.Context) (meta *BuildMeta, err e
 	}
 
 	// install the package
-	ctx.status = "install"
+	ctx.status.Store("install")
 	err = ctx.install()
 	if err != nil {
 		return
@@ -171,12 +171,12 @@ func (ctx *BuildContext) Build(buildCtx context.Context) (meta *BuildMeta, err e
 
 	// analyze splitting modules if bundling
 	if ctx.pkgJson.Exports.Len() > 1 && (ctx.shouldBundle() || ctx.shouldBundleInternalModules()) {
-		ctx.status = "analyze"
+		ctx.status.Store("analyze")
 		ctx.analyzeSplitting()
 	}
 
 	// build the module
-	ctx.status = "build"
+	ctx.status.Store("build")
 	meta, _, err = ctx.buildModule(false)
 	if err != nil {
 		return
@@ -1547,7 +1547,7 @@ REBUILD:
 
 func (ctx *BuildContext) buildTypes() (ret *BuildMeta, err error) {
 	// install the package
-	ctx.status = "install"
+	ctx.status.Store("install")
 	err = ctx.install()
 	if err != nil {
 		return
@@ -1568,7 +1568,7 @@ func (ctx *BuildContext) buildTypes() (ret *BuildMeta, err error) {
 		dts = entry.types
 	}
 
-	ctx.status = "build"
+	ctx.status.Store("build")
 	err = ctx.transformDTS(dts)
 	if err != nil {
 		return
@@ -1622,7 +1622,6 @@ func (ctx *BuildContext) install() (err error) {
 			}
 			if isMainModule {
 				ctx.esmPath.SubPath = ""
-				ctx.rawPath = ctx.path
 				ctx.path = ""
 			}
 		}

--- a/server/build_queue.go
+++ b/server/build_queue.go
@@ -1,187 +1,154 @@
 package server
 
 import (
-	"container/list"
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 )
 
-// BuildQueue schedules build tasks of esm.sh
+// BuildQueue runs builds in FIFO order, sharing results for the same requested path.
 type BuildQueue struct {
-	lock      sync.Mutex
-	tasks     map[string]*BuildTask
-	queue     map[*BuildTask]struct{}
-	pending   *list.List
-	chann     int
-	scheduler bool
+	lock        sync.Mutex
+	tasks       map[string]*buildTask
+	pending     []*buildTask
+	running     int
+	concurrency int
+	timeout     time.Duration
 }
 
-type BuildTask struct {
-	ctx       *BuildContext
-	waitChans []chan BuildOutput
-	createdAt time.Time
-	startedAt time.Time
+type buildTask struct {
+	ctx         *BuildContext
+	path        string // the queue key stays fixed when installation changes ctx.Path()
+	done        chan struct{}
+	meta        *BuildMeta
+	err         error
+	waitClients int
+	createdAt   time.Time
+	startedAt   time.Time
 }
 
-type BuildOutput struct {
-	meta *BuildMeta
-	err  error
-}
-
-func NewBuildQueue(concurrency int) *BuildQueue {
+func NewBuildQueue(concurrency int, timeout time.Duration) *BuildQueue {
 	if concurrency <= 0 {
-		concurrency = 1 // ensure at least 1 concurrent task
+		concurrency = 1
+	}
+	if timeout <= 0 {
+		timeout = 10 * time.Minute
 	}
 	return &BuildQueue{
-		queue:   map[*BuildTask]struct{}{},
-		pending: list.New(),
-		tasks:   map[string]*BuildTask{},
-		chann:   concurrency,
+		tasks:       map[string]*buildTask{},
+		concurrency: concurrency,
+		timeout:     timeout,
 	}
 }
 
-// Add adds a new build task to the queue.
-func (q *BuildQueue) Add(ctx *BuildContext) chan BuildOutput {
+// Build waits for a shared build. Canceling the wait leaves the build running.
+func (q *BuildQueue) Build(ctx context.Context, build *BuildContext) (*BuildMeta, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	path := build.Path()
 	q.lock.Lock()
-	defer q.lock.Unlock()
-
-	ch := make(chan BuildOutput, 1)
-
-	task, ok := q.tasks[ctx.Path()]
-	if ok {
-		task.waitChans = append(task.waitChans, ch)
-		return ch
+	task := q.tasks[path]
+	if task == nil {
+		task = &buildTask{
+			ctx:       build,
+			path:      path,
+			done:      make(chan struct{}),
+			createdAt: time.Now(),
+		}
+		build.status.Store("pending")
+		q.tasks[path] = task
+		q.pending = append(q.pending, task)
 	}
+	task.waitClients++
+	q.scheduleLocked()
+	q.lock.Unlock()
 
-	task = &BuildTask{
-		ctx:       ctx,
-		createdAt: time.Now(),
-		waitChans: []chan BuildOutput{ch},
+	defer func() {
+		q.lock.Lock()
+		task.waitClients--
+		q.lock.Unlock()
+	}()
+
+	select {
+	case <-task.done:
+		if build != task.ctx {
+			build.path = task.ctx.path
+			build.esmPath = task.ctx.esmPath
+		}
+		return task.meta, task.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
-	ctx.status = "pending"
-
-	q.pending.PushBack(task)
-	q.tasks[ctx.Path()] = task
-
-	q.startSchedulerLocked()
-
-	return ch
 }
 
 func (q *BuildQueue) Snapshot() []map[string]any {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
-	items := make([]map[string]any, 0, len(q.queue)+q.pending.Len())
-	for task := range q.queue {
-		items = append(items, map[string]any{
-			"waitClients": len(task.waitChans),
-			"createdAt":   task.createdAt.Format(time.RFC1123),
-			"path":        task.ctx.Path(),
-			"status":      task.ctx.status,
-		})
+	tasks := make([]*buildTask, 0, len(q.tasks))
+	for _, task := range q.tasks {
+		tasks = append(tasks, task)
 	}
-	for el := q.pending.Front(); el != nil; el = el.Next() {
-		task, ok := el.Value.(*BuildTask)
-		if !ok {
-			continue
-		}
+	slices.SortFunc(tasks, func(a, b *buildTask) int {
+		return a.createdAt.Compare(b.createdAt)
+	})
+	items := make([]map[string]any, 0, len(tasks))
+	for _, task := range tasks {
 		items = append(items, map[string]any{
-			"waitClients": len(task.waitChans),
+			"waitClients": task.waitClients,
 			"createdAt":   task.createdAt.Format(time.RFC1123),
-			"path":        task.ctx.Path(),
-			"status":      task.ctx.status,
+			"path":        task.path,
+			"status":      task.ctx.status.Load(),
 		})
 	}
 	return items
 }
 
-func (q *BuildQueue) startSchedulerLocked() {
-	if q.scheduler || q.chann == 0 || q.pending.Len() == 0 {
-		return
-	}
-	q.scheduler = true
-	go q.schedule()
-}
-
-func (q *BuildQueue) schedule() {
-	for {
-		q.lock.Lock()
-		if q.chann == 0 || q.pending.Len() == 0 {
-			q.scheduler = false
-			q.lock.Unlock()
-			return
+// scheduleLocked starts pending tasks while capacity is available.
+func (q *BuildQueue) scheduleLocked() {
+	for q.running < q.concurrency && len(q.pending) > 0 {
+		task := q.pending[0]
+		q.pending[0] = nil
+		q.pending = q.pending[1:]
+		if len(q.pending) == 0 {
+			q.pending = nil
 		}
-
-		task, _ := q.pending.Remove(q.pending.Front()).(*BuildTask)
-		q.queue[task] = struct{}{}
 		task.startedAt = time.Now()
-		q.chann--
-		q.lock.Unlock()
-
+		task.ctx.status.Store("build")
+		q.running++
 		go q.run(task)
 	}
 }
 
-func (q *BuildQueue) run(task *BuildTask) {
-	var output BuildOutput
-
+func (q *BuildQueue) run(task *buildTask) {
 	defer func() {
 		if r := recover(); r != nil {
-			output.err = fmt.Errorf("build panic: %v", r)
-			task.ctx.status = "error"
-			task.ctx.logger.Errorf("build '%s' panicked: %v", task.ctx.Path(), r)
+			task.err = fmt.Errorf("build panic: %v", r)
 		}
-
-		waitChans := task.waitChans
+		if logger := task.ctx.logger; logger != nil {
+			if task.err != nil {
+				logger.Errorf("build '%s': %v", task.path, task.err)
+			} else {
+				logger.Infof("build '%s'(%s) done in %v", task.ctx.Path(), task.ctx.target, time.Since(task.startedAt))
+			}
+		}
 
 		q.lock.Lock()
-		q.chann++
-		delete(q.queue, task)
-		delete(q.tasks, task.ctx.Path())
-		if task.ctx.rawPath != "" {
-			// the `Build` function may have changed the path
-			delete(q.tasks, task.ctx.rawPath)
-		}
-		q.startSchedulerLocked()
+		delete(q.tasks, task.path)
+		q.running--
+		close(task.done)
+		q.scheduleLocked()
 		q.lock.Unlock()
-
-		for _, ch := range waitChans {
-			if ch == nil {
-				continue
-			}
-			select {
-			case ch <- output:
-			default:
-				// the request may have already timed out while waiting on the build
-			}
-		}
 	}()
 
-	buildTimeout := 10 * time.Minute
-	if config != nil && config.BuildTimeout > 0 {
-		buildTimeout = time.Duration(config.BuildTimeout) * time.Second
-	}
-	buildCtx, cancel := context.WithTimeout(context.Background(), buildTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), q.timeout)
 	defer cancel()
-
-	meta, err := task.ctx.Build(buildCtx)
-	if errors.Is(err, context.DeadlineExceeded) {
-		err = fmt.Errorf("build timeout after %d seconds", buildTimeout/time.Second)
+	task.meta, task.err = task.ctx.Build(ctx)
+	if errors.Is(task.err, context.DeadlineExceeded) {
+		task.err = fmt.Errorf("build timeout after %d seconds", q.timeout/time.Second)
 	}
-	if err == nil {
-		task.ctx.status = "done"
-		if task.ctx.target == "types" {
-			task.ctx.logger.Infof("build '%s'(types) done in %v", task.ctx.Path(), time.Since(task.startedAt))
-		} else {
-			task.ctx.logger.Infof("build '%s' done in %v", task.ctx.Path(), time.Since(task.startedAt))
-		}
-	} else {
-		task.ctx.status = "error"
-		task.ctx.logger.Errorf("build '%s': %v", task.ctx.Path(), err)
-	}
-	output = BuildOutput{meta: meta, err: err}
 }

--- a/server/build_queue_test.go
+++ b/server/build_queue_test.go
@@ -1,0 +1,346 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/esm-dev/esm.sh/internal/storage"
+)
+
+type buildQueueTestStorage struct {
+	storage.Storage
+	get func() (*BuildMeta, error)
+}
+
+func (s buildQueueTestStorage) Get(string) (io.ReadCloser, storage.Stat, error) {
+	meta, err := s.get()
+	if err != nil {
+		return nil, nil, err
+	}
+	return io.NopCloser(bytes.NewReader(encodeBuildMeta(meta))), nil, nil
+}
+
+func newBuildQueueTestContext(path string, get func() (*BuildMeta, error)) *BuildContext {
+	cacheLRU.Remove(path)
+	return &BuildContext{path: path, metaDB: NewBuildMetaDB(buildQueueTestStorage{get: get})}
+}
+
+func TestBuildQueueScheduling(t *testing.T) {
+	for _, concurrency := range []int{-1, 0, 1, 3} {
+		t.Run(fmt.Sprint(concurrency), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				q := NewBuildQueue(concurrency, 0)
+				limit := max(1, concurrency)
+				const count = 6
+				started := make(chan int, count)
+				finished := make(chan int, count)
+				release := make([]chan struct{}, count)
+				for i := range count {
+					release[i] = make(chan struct{})
+					build := newBuildQueueTestContext(fmt.Sprintf("/%s/%d", t.Name(), i), func() (*BuildMeta, error) {
+						started <- i
+						<-release[i]
+						return &BuildMeta{Dts: fmt.Sprint(i)}, nil
+					})
+					go func() {
+						meta, err := q.Build(context.Background(), build)
+						if err != nil || meta == nil || meta.Dts != fmt.Sprint(i) {
+							t.Errorf("build %d: meta=%+v, err=%v", i, meta, err)
+						}
+						finished <- i
+					}()
+					synctest.Wait()
+					time.Sleep(time.Nanosecond)
+				}
+				for i, item := range q.Snapshot() {
+					status := "pending"
+					if i < limit {
+						status = "build"
+					}
+					if item["path"] != fmt.Sprintf("/%s/%d", t.Name(), i) || item["status"] != status || item["waitClients"] != 1 {
+						t.Fatalf("unexpected task %d: %+v", i, item)
+					}
+				}
+				if len(started) != limit {
+					t.Fatalf("started %d builds, want %d", len(started), limit)
+				}
+				for i := range limit {
+					if got := <-started; got != i {
+						t.Fatalf("started %d, want %d", got, i)
+					}
+				}
+				for i := range count {
+					close(release[i])
+					synctest.Wait()
+					if got := <-finished; got != i {
+						t.Fatalf("finished %d, want %d", got, i)
+					}
+					if next := i + limit; next < count {
+						if len(started) != 1 {
+							t.Fatalf("started %d new builds, want 1", len(started))
+						}
+						if got := <-started; got != next {
+							t.Fatalf("started %d, want %d", got, next)
+						}
+					}
+				}
+				if len(q.Snapshot()) != 0 {
+					t.Fatal("finished tasks remain in the queue")
+				}
+			})
+		})
+	}
+}
+
+func TestBuildQueueWaitCancellation(t *testing.T) {
+	for _, pending := range []bool{false, true} {
+		t.Run(fmt.Sprintf("pending=%v", pending), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				q := NewBuildQueue(1, time.Minute)
+				unblock := make(chan struct{})
+				if pending {
+					blocker := newBuildQueueTestContext("/"+t.Name()+"/blocker", func() (*BuildMeta, error) {
+						<-unblock
+						return &BuildMeta{}, nil
+					})
+					go func() {
+						if _, err := q.Build(context.Background(), blocker); err != nil {
+							t.Error(err)
+						}
+					}()
+					synctest.Wait()
+				}
+				release := make(chan struct{})
+				path := "/" + t.Name() + "/shared"
+				build := newBuildQueueTestContext(path, func() (*BuildMeta, error) {
+					<-release
+					return &BuildMeta{ExportDefault: true}, nil
+				})
+				waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+				defer cancel()
+				go func() {
+					if _, err := q.Build(waitCtx, build); !errors.Is(err, context.DeadlineExceeded) {
+						t.Errorf("expected wait timeout, got %v", err)
+					}
+				}()
+				synctest.Wait()
+				time.Sleep(time.Second)
+				synctest.Wait()
+				for _, item := range q.Snapshot() {
+					if item["path"] == path && item["waitClients"] != 0 {
+						t.Fatalf("timed out waiter retained: %+v", item)
+					}
+				}
+				if !pending && build.Context().Err() != nil {
+					t.Fatal("request timeout canceled the shared build")
+				}
+				const clients = 64
+				finished := make(chan struct{}, clients)
+				for range clients {
+					go func() {
+						meta, err := q.Build(context.Background(), &BuildContext{path: path})
+						if err != nil || meta == nil || !meta.ExportDefault {
+							t.Errorf("shared result: meta=%+v, err=%v", meta, err)
+						}
+						finished <- struct{}{}
+					}()
+				}
+				synctest.Wait()
+				for _, item := range q.Snapshot() {
+					if item["path"] == path && item["waitClients"] != clients {
+						t.Fatalf("waiters did not join the existing build: %+v", item)
+					}
+				}
+				close(unblock)
+				synctest.Wait()
+				close(release)
+				synctest.Wait()
+				if len(finished) != clients || len(q.Snapshot()) != 0 {
+					t.Fatalf("finished %d/%d waiters; queue: %+v", len(finished), clients, q.Snapshot())
+				}
+				canceled, stop := context.WithCancel(context.Background())
+				stop()
+				if _, err := q.Build(canceled, nil); !errors.Is(err, context.Canceled) {
+					t.Fatalf("expected cancellation before enqueue, got %v", err)
+				}
+			})
+		})
+	}
+}
+
+func TestBuildQueueFailure(t *testing.T) {
+	for _, failure := range []string{"error", "panic", "timeout"} {
+		t.Run(failure, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				q := NewBuildQueue(1, time.Second)
+				release := make(chan struct{})
+				path := "/" + t.Name()
+				want := "failed"
+				build := newBuildQueueTestContext(path, nil)
+				build.metaDB = NewBuildMetaDB(buildQueueTestStorage{get: func() (*BuildMeta, error) {
+					if failure == "timeout" {
+						<-build.Context().Done()
+					}
+					<-release
+					switch failure {
+					case "panic":
+						panic("failed")
+					case "timeout":
+						return nil, build.Context().Err()
+					default:
+						return nil, errors.New("failed")
+					}
+				}})
+				if failure == "panic" {
+					want = "build panic: failed"
+				} else if failure == "timeout" {
+					want = "build timeout after 1 seconds"
+				}
+				errorsReceived := make(chan error, 2)
+				go func() {
+					_, err := q.Build(context.Background(), build)
+					errorsReceived <- err
+				}()
+				synctest.Wait()
+				go func() {
+					_, err := q.Build(context.Background(), &BuildContext{path: path})
+					errorsReceived <- err
+				}()
+				nextStarted := make(chan struct{}, 1)
+				next := newBuildQueueTestContext(path+"/next", func() (*BuildMeta, error) {
+					nextStarted <- struct{}{}
+					return &BuildMeta{}, nil
+				})
+				go func() {
+					if _, err := q.Build(context.Background(), next); err != nil {
+						t.Error(err)
+					}
+				}()
+				synctest.Wait()
+				if failure == "timeout" {
+					time.Sleep(time.Second)
+					synctest.Wait()
+					if len(nextStarted) != 0 {
+						t.Fatal("released capacity before the timed out build exited")
+					}
+				}
+				close(release)
+				synctest.Wait()
+				if len(errorsReceived) != 2 || len(nextStarted) != 1 || len(q.Snapshot()) != 0 {
+					t.Fatalf("failure did not release waiters and capacity: errors=%d, next=%d, queue=%+v", len(errorsReceived), len(nextStarted), q.Snapshot())
+				}
+				for range 2 {
+					if err := <-errorsReceived; err == nil || err.Error() != want {
+						t.Fatalf("got %v, want %q", err, want)
+					}
+				}
+				retry := newBuildQueueTestContext(path, func() (*BuildMeta, error) { return &BuildMeta{}, nil })
+				if _, err := q.Build(context.Background(), retry); err != nil {
+					t.Fatalf("retry failed: %v", err)
+				}
+			})
+		})
+	}
+}
+
+func TestBuildQueuePathChange(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		q := NewBuildQueue(2, time.Minute)
+		aliasPath, canonicalPath := "/"+t.Name()+"/index", "/"+t.Name()+"/root"
+		releaseAlias, releaseCanonical := make(chan struct{}), make(chan struct{})
+		alias := newBuildQueueTestContext(aliasPath, nil)
+		alias.esmPath.SubPath = "index"
+		alias.metaDB = NewBuildMetaDB(buildQueueTestStorage{get: func() (*BuildMeta, error) {
+			alias.path = canonicalPath
+			alias.esmPath.SubPath = ""
+			alias.status.Store("install")
+			<-releaseAlias
+			return &BuildMeta{}, nil
+		}})
+		canonical := newBuildQueueTestContext(canonicalPath, func() (*BuildMeta, error) {
+			<-releaseCanonical
+			return &BuildMeta{}, nil
+		})
+		for _, build := range []*BuildContext{alias, canonical} {
+			go func() {
+				if _, err := q.Build(context.Background(), build); err != nil {
+					t.Error(err)
+				}
+			}()
+		}
+		synctest.Wait()
+		duplicate := &BuildContext{path: aliasPath, esmPath: EsmPath{SubPath: "index"}}
+		go func() {
+			if _, err := q.Build(context.Background(), duplicate); err != nil {
+				t.Error(err)
+			}
+		}()
+		synctest.Wait()
+		for _, item := range q.Snapshot() {
+			if item["path"] == aliasPath && (item["status"] != "install" || item["waitClients"] != 2) {
+				t.Fatalf("unexpected alias task: %+v", item)
+			}
+		}
+		close(releaseAlias)
+		synctest.Wait()
+		if duplicate.Path() != canonicalPath || duplicate.esmPath.SubPath != "" {
+			t.Fatalf("joined request did not receive the resolved path: %+v", duplicate)
+		}
+		items := q.Snapshot()
+		if len(items) != 1 || items[0]["path"] != canonicalPath {
+			t.Fatalf("completion removed the wrong task: %+v", items)
+		}
+		go func() {
+			if _, err := q.Build(context.Background(), &BuildContext{path: canonicalPath}); err != nil {
+				t.Error(err)
+			}
+		}()
+		synctest.Wait()
+		items = q.Snapshot()
+		if len(items) != 1 || items[0]["waitClients"] != 2 {
+			t.Fatalf("canonical build lost deduplication: %+v", items)
+		}
+		close(releaseCanonical)
+		synctest.Wait()
+	})
+}
+
+func TestBuildQueueSnapshotDuringBuild(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		q := NewBuildQueue(1, time.Minute)
+		start, release := make(chan struct{}), make(chan struct{})
+		path := "/" + t.Name()
+		build := newBuildQueueTestContext(path, nil)
+		build.metaDB = NewBuildMetaDB(buildQueueTestStorage{get: func() (*BuildMeta, error) {
+			<-start
+			for range 1000 {
+				build.path = path + "/resolved"
+				build.status.Store("install")
+				build.status.Store("build")
+			}
+			<-release
+			return &BuildMeta{}, nil
+		}})
+		go func() {
+			if _, err := q.Build(context.Background(), build); err != nil {
+				t.Error(err)
+			}
+		}()
+		synctest.Wait()
+		close(start)
+		for range 1000 {
+			items := q.Snapshot()
+			if len(items) != 1 || items[0]["path"] != path || (items[0]["status"] != "install" && items[0]["status"] != "build") {
+				t.Fatalf("unexpected snapshot: %+v", items)
+			}
+		}
+		close(release)
+		synctest.Wait()
+	})
+}

--- a/server/router.go
+++ b/server/router.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha1"
 	"crypto/sha512"
 	"encoding/base64"
@@ -61,7 +62,7 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) http.Handler {
 	var (
 		startTime  = time.Now()
 		globalETag = fmt.Sprintf(`W/"%s"`, VERSION)
-		buildQueue = NewBuildQueue(int(config.BuildConcurrency))
+		buildQueue = NewBuildQueue(int(config.BuildConcurrency), time.Duration(config.BuildTimeout)*time.Second)
 		npmrc      = DefaultNpmRC()
 		metaDB     = NewBuildMetaDB(esmStorage)
 	)
@@ -1251,25 +1252,28 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) http.Handler {
 					externalAll: externalAll,
 					target:      "types",
 				}
-				ch := buildQueue.Add(buildCtx)
-				select {
-				case output := <-ch:
-					if output.err != nil {
-						if output.err.Error() == "types not found" {
-							if isExactVersion {
-								header.Set("Cache-Control", ccImmutable)
-							} else {
-								header.Set("Cache-Control", ccOneDay)
-							}
-							writeStatus(w, 404, "Types Not Found")
-							return
-						}
-						writeStatus(w, 500, "Failed to build types: "+output.err.Error())
-						return
-					}
-				case <-time.After(time.Duration(config.BuildWaitTime) * time.Second):
+				waitCtx, cancel := context.WithTimeout(r.Context(), time.Duration(config.BuildWaitTime)*time.Second)
+				_, err = buildQueue.Build(waitCtx, buildCtx)
+				cancel()
+				if r.Context().Err() != nil {
+					return
+				}
+				if errors.Is(err, context.DeadlineExceeded) {
 					header.Set("Cache-Control", ccMustRevalidate)
 					writeStatus(w, http.StatusRequestTimeout, "timeout, the types is waiting to be built, please try refreshing the page.")
+					return
+				}
+				if err != nil {
+					if err.Error() == "types not found" {
+						if isExactVersion {
+							header.Set("Cache-Control", ccImmutable)
+						} else {
+							header.Set("Cache-Control", ccOneDay)
+						}
+						writeStatus(w, 404, "Types Not Found")
+						return
+					}
+					writeStatus(w, 500, "Failed to build types: "+err.Error())
 					return
 				}
 				content, _, err = readDts()
@@ -1364,27 +1368,29 @@ func esmRouter(esmStorage storage.Storage, logger *log.Logger) http.Handler {
 			return
 		}
 		if !ok {
-			ch := buildQueue.Add(build)
-			select {
-			case output := <-ch:
-				if output.err != nil {
-					msg := output.err.Error()
-					if msg == "could not resolve build entry" || strings.HasSuffix(msg, " not found") || strings.Contains(msg, "is not exported from package") || strings.Contains(msg, "no such file or directory") {
-						header.Set("Cache-Control", fmt.Sprintf("public, max-age=%d", config.NpmQueryCacheTTL))
-						writeStatus(w, 404, msg)
-						return
-					}
-					writeStatus(w, 500, msg)
-					return
-				}
-				buildMeta = output.meta
-				// Follow a freshly built version in the default URL immediately.
-				invalidateDistTagCacheIfNewer(esmPath.PkgName, esmPath.PkgVersion)
-			case <-time.After(time.Duration(config.BuildWaitTime) * time.Second):
+			waitCtx, cancel := context.WithTimeout(r.Context(), time.Duration(config.BuildWaitTime)*time.Second)
+			buildMeta, err = buildQueue.Build(waitCtx, build)
+			cancel()
+			if r.Context().Err() != nil {
+				return
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
 				header.Set("Cache-Control", ccMustRevalidate)
 				writeStatus(w, http.StatusRequestTimeout, "timeout, the module is waiting to be built, please try refreshing the page.")
 				return
 			}
+			if err != nil {
+				msg := err.Error()
+				if msg == "could not resolve build entry" || strings.HasSuffix(msg, " not found") || strings.Contains(msg, "is not exported from package") || strings.Contains(msg, "no such file or directory") {
+					header.Set("Cache-Control", fmt.Sprintf("public, max-age=%d", config.NpmQueryCacheTTL))
+					writeStatus(w, 404, msg)
+					return
+				}
+				writeStatus(w, 500, msg)
+				return
+			}
+			// Follow a freshly built version in the default URL immediately.
+			invalidateDistTagCacheIfNewer(esmPath.PkgName, esmPath.PkgVersion)
 		}
 
 		if buildMeta.CSSEntry != "" {


### PR DESCRIPTION
Concurrent requests for the same build could race with completion, and path normalization could remove another task from the queue. Replace the scheduler goroutine and per-request result channels with a FIFO pending queue and one shared completion signal per requested path.

Request cancellation now detaches the waiter while the shared build continues. Queue keys remain fixed, status updates are atomic, and joined requests receive the resolved build path. Concurrency limits, build timeouts, and panic recovery are preserved.

Pin the import-map resolution test to React DOM 19.2.4 so its scheduler 0.27.x expectation stays consistent with the fixture, and report setup errors directly.

Validation:
- `go test ./server ./internal/... -count=1` passes.
- `go test -race ./server -run '^TestBuildQueue' -count=25` passes.
- Regression coverage includes FIFO scheduling, deduplication, waiter cancellation, path changes, snapshots, failures, and retries.
