### PR TITLE
Fix storage, import maps, builds, and CLI handling

### DIFF
--- a/cli/command_add.go
+++ b/cli/command_add.go
@@ -94,23 +94,28 @@ func updateImportMap(specifiers []string, all bool, noPrompt bool, noSRI bool) (
 		if err != nil {
 			return
 		}
+		defer f.Close()
 		tokenizer := html.NewTokenizer(f)
 		buf := bytes.NewBuffer(nil)
 		updated := false
 		for {
 			token := tokenizer.Next()
-			if token == html.ErrorToken && tokenizer.Err() == io.EOF {
+			if token == html.ErrorToken {
+				if tokenizer.Err() != io.EOF {
+					return tokenizer.Err()
+				}
 				break
 			}
 			if token == html.EndTagToken {
 				tagName, _ := tokenizer.TagName()
 				if string(tagName) == "head" && !updated {
 					buf.WriteString("  <script type=\"importmap\">\n")
-					var importMap importmap.ImportMap
-					if addImports(&importMap, specifiers, all, noPrompt, noSRI) {
-						buf.WriteString(importMap.FormatJSON(2))
-						buf.WriteString("\n  </script>\n")
+					importMap := importmap.Blank()
+					if !addImports(importMap, specifiers, all, noPrompt, noSRI) {
+						return fmt.Errorf("could not resolve imports")
 					}
+					buf.WriteString(importMap.FormatJSON(2))
+					buf.WriteString("\n  </script>\n")
 					buf.Write(tokenizer.Raw())
 					updated = true
 					continue
@@ -131,10 +136,11 @@ func updateImportMap(specifiers []string, all bool, noPrompt bool, noSRI bool) (
 					if typeAttr != "importmap" && !updated {
 						buf.WriteString("<script type=\"importmap\">\n")
 						importMap := importmap.Blank()
-						if addImports(importMap, specifiers, all, noPrompt, noSRI) {
-							buf.WriteString(importMap.FormatJSON(2))
-							buf.WriteString("\n  </script>\n  ")
+						if !addImports(importMap, specifiers, all, noPrompt, noSRI) {
+							return fmt.Errorf("could not resolve imports")
 						}
+						buf.WriteString(importMap.FormatJSON(2))
+						buf.WriteString("\n  </script>\n  ")
 						buf.Write(tokenizer.Raw())
 						updated = true
 						continue
@@ -154,13 +160,12 @@ func updateImportMap(specifiers []string, all bool, noPrompt bool, noSRI bool) (
 								}
 							}
 						}
-						if addImports(importMap, specifiers, all, noPrompt, noSRI) {
-							buf.WriteString("\n")
-							buf.WriteString(importMap.FormatJSON(2))
-							buf.WriteString("\n  ")
-						} else {
-							buf.Write(tagContent)
+						if !addImports(importMap, specifiers, all, noPrompt, noSRI) {
+							return fmt.Errorf("could not resolve imports")
 						}
+						buf.WriteString("\n")
+						buf.WriteString(importMap.FormatJSON(2))
+						buf.WriteString("\n  ")
 						if token == html.EndTagToken {
 							buf.Write(tokenizer.Raw())
 						}
@@ -179,21 +184,18 @@ func updateImportMap(specifiers []string, all bool, noPrompt bool, noSRI bool) (
 		err = os.WriteFile(indexHtml, buf.Bytes(), fi.Mode())
 	} else {
 		importMap := importmap.Blank()
-		if addImports(importMap, specifiers, all, noPrompt, noSRI) {
-			err = os.WriteFile(indexHtml, fmt.Appendf(nil, htmlTemplate, importMap.FormatJSON(2), specifiers[0]), 0644)
-			if err == nil {
-				fmt.Println(term.Dim("Created index.html with importmap script."))
-			}
+		if !addImports(importMap, specifiers, all, noPrompt, noSRI) {
+			return fmt.Errorf("could not resolve imports")
+		}
+		err = os.WriteFile(indexHtml, fmt.Appendf(nil, htmlTemplate, importMap.FormatJSON(2), specifiers[0]), 0644)
+		if err == nil {
+			fmt.Println(term.Dim("Created index.html with importmap script."))
 		}
 	}
 	return
 }
 
 func addImports(im *importmap.ImportMap, specifiers []string, all bool, noPrompt bool, noSRI bool) bool {
-	// for debug
-	// im.AddImportFromSpecifier(specifiers[0], noSRI)
-	// return true
-
 	term.HideCursor()
 	defer term.ShowCursor()
 
@@ -213,10 +215,13 @@ func addImports(im *importmap.ImportMap, specifiers []string, all bool, noPrompt
 	var addedSpecifiers []string
 	var warnings []string
 	var errors []error
+	var lock sync.Mutex
 	var wg sync.WaitGroup
 	for _, specifier := range specifiers {
 		wg.Go(func() {
 			imp, err := im.ParseImport(specifier)
+			lock.Lock()
+			defer lock.Unlock()
 			if err != nil {
 				errors = append(errors, err)
 				return
@@ -246,6 +251,8 @@ func addImports(im *importmap.ImportMap, specifiers []string, all bool, noPrompt
 								Jsr:     imp.Jsr,
 								Dev:     imp.Dev,
 							})
+							lock.Lock()
+							defer lock.Unlock()
 							if err != nil {
 								errors = append(errors, err)
 								return
@@ -275,7 +282,7 @@ func addImports(im *importmap.ImportMap, specifiers []string, all bool, noPrompt
 
 	spinner.Stop()
 
-	if !noPrompt {
+	if !noPrompt && !all {
 		term := newTermRaw()
 		if term.isTTY() {
 			for _, imp := range resolvedImports {
@@ -332,7 +339,6 @@ type subModuleSelectUI struct {
 	spinnerIndex int
 	spinnerTimer *time.Timer
 	spinnerChars []string
-	termWidth    int
 	termHeight   int
 }
 
@@ -343,9 +349,8 @@ func (ui *subModuleSelectUI) init(subModules []string) {
 	ui.state = make([]uint8, len(ui.subModules))
 	ui.state[0] = 1
 	ui.spinnerChars = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
-	width, height, err := ui.term.GetSize()
+	_, height, err := ui.term.GetSize()
 	if err == nil {
-		ui.termWidth = width
 		ui.termHeight = height
 	}
 }
@@ -383,7 +388,7 @@ func (ui *subModuleSelectUI) show() {
 				ui.state[cur] = 2
 				ui.startSpinner()
 				go func() {
-					errors, _ := ui.im.AddImportFromSpecifier(ui.toSpecifier(cur, true), ui.noSRI)
+					_, errors := ui.im.AddImportFromSpecifier(ui.toSpecifier(cur, true), ui.noSRI)
 					if len(errors) > 0 {
 						ui.state[cur] = 3
 					} else {
@@ -404,7 +409,7 @@ func (ui *subModuleSelectUI) show() {
 					ui.state[i] = 2
 					ui.startSpinner()
 					go func() {
-						errors, _ := ui.im.AddImportFromSpecifier(specifier, ui.noSRI)
+						_, errors := ui.im.AddImportFromSpecifier(specifier, ui.noSRI)
 						if len(errors) > 0 {
 							ui.state[i] = 3
 						} else {
@@ -445,16 +450,14 @@ func (ui *subModuleSelectUI) isPending() bool {
 }
 
 func (ui *subModuleSelectUI) clearLines() {
-	func() {
-		height := ui.maxLines() + 1
-		term.MoveCursorUp(height)
-		for range height {
-			term.ClearLine()
-			os.Stdout.Write(EOL) // move to the next line
-		}
+	height := ui.maxLines() + 1
+	term.MoveCursorUp(height)
+	for range height {
 		term.ClearLine()
-		term.MoveCursorUp(height)
-	}()
+		os.Stdout.Write(EOL) // move to the next line
+	}
+	term.ClearLine()
+	term.MoveCursorUp(height)
 }
 
 func (ui *subModuleSelectUI) maxLines() int {

--- a/cli/command_add_test.go
+++ b/cli/command_add_test.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/esm-dev/esm.sh/internal/importmap"
+)
+
+func TestUpdateImportMapFailurePreservesHTML(t *testing.T) {
+	for _, source := range []string{
+		"<html><head></head><body></body></html>",
+		`<html><head><script type="module"></script></head></html>`,
+		`<html><head><script type="importmap">{"imports":{}}</script></head></html>`,
+	} {
+		t.Run(source, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			if err := os.WriteFile("index.html", []byte(source), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := updateImportMap([]string{"invalid package"}, false, true, true); err == nil {
+				t.Fatal("expected resolution error")
+			}
+			got, err := os.ReadFile("index.html")
+			if err != nil || string(got) != source {
+				t.Fatalf("index.html changed on failure: %q, %v", got, err)
+			}
+		})
+	}
+}
+
+func TestUpdateImportMapWithoutScript(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("index.html", []byte("<html><head></head></html>"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := updateImportMap(nil, false, true, true); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile("index.html")
+	if err != nil || !strings.Contains(string(got), "\"imports\": {}") || !strings.Contains(string(got), "</script>\n</head>") {
+		t.Fatalf("invalid HTML: %q, %v", got, err)
+	}
+}
+
+func TestAddImportsConcurrentErrors(t *testing.T) {
+	specifiers := make([]string, 64)
+	for i := range specifiers {
+		specifiers[i] = "invalid package"
+	}
+	if addImports(importmap.Blank(), specifiers, false, true, true) {
+		t.Fatal("invalid imports succeeded")
+	}
+}
+
+func TestLookupClosestFileStatError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.Symlink("index.html", "index.html"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := lookupClosestFile("index.html"); err == nil {
+		t.Fatal("expected symlink loop error")
+	}
+}
+
+func TestLookupClosestFileParent(t *testing.T) {
+	dir := t.TempDir()
+	filename := filepath.Join(dir, "index.html")
+	if err := os.WriteFile(filename, nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	child := filepath.Join(dir, "child")
+	if err := os.Mkdir(child, 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(child)
+	got, exists, err := lookupClosestFile("index.html")
+	if err != nil || !exists || got != filename {
+		t.Fatalf("lookup = %q, %v, %v", got, exists, err)
+	}
+}

--- a/cli/command_tidy.go
+++ b/cli/command_tidy.go
@@ -42,7 +42,7 @@ func Tidy() {
 func tidy(noSRI bool) (err error) {
 	indexHtml, exists, err := lookupClosestFile("index.html")
 	if err != nil {
-		err = fmt.Errorf("Failed to lookup index.html: %w", err)
+		err = fmt.Errorf("failed to lookup index.html: %w", err)
 		return
 	}
 
@@ -55,12 +55,16 @@ func tidy(noSRI bool) (err error) {
 	if err != nil {
 		return
 	}
+	defer f.Close()
 
 	tokenizer := html.NewTokenizer(f)
 	buf := bytes.NewBuffer(nil)
 	for {
 		token := tokenizer.Next()
-		if token == html.ErrorToken && tokenizer.Err() == io.EOF {
+		if token == html.ErrorToken {
+			if tokenizer.Err() != io.EOF {
+				return tokenizer.Err()
+			}
 			break
 		}
 		if token == html.StartTagToken {
@@ -96,15 +100,16 @@ func tidy(noSRI bool) (err error) {
 					importMap := importmap.Blank()
 					importMap.SetConfig(prevImportMap.Config())
 					importMap.SetIntegrity(prevImportMap.Integrity())
+					cdn := prevImportMap.Config().CDN
+					if !strings.HasPrefix(cdn, "https://") && !strings.HasPrefix(cdn, "http://") {
+						cdn = "https://esm.sh"
+					}
 					imports := make([]importmap.Import, 0, prevImportMap.Imports.Len())
 					prevImportMap.Imports.Range(func(specifier string, url string) bool {
-						if strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "http://") {
-							// todo: check hostname
+						if strings.HasPrefix(url, cdn+"/") {
 							imp, err := importmap.ParseEsmPath(url)
-							if err == nil {
-								if npm.IsExactVersion(imp.Version) {
-									imports = append(imports, imp)
-								}
+							if err == nil && npm.IsExactVersion(imp.Version) && specifier == imp.Specifier(false) {
+								imports = append(imports, imp)
 								return true // continue
 							}
 						}
@@ -112,11 +117,8 @@ func tidy(noSRI bool) (err error) {
 						return true
 					})
 					prevImportMap.RangeScopes(func(scope string, imports *importmap.Imports) bool {
-						if strings.HasPrefix(scope, "https://") || strings.HasPrefix(scope, "http://") {
-							// todo: check hostname
-							if strings.HasSuffix(scope, "/") {
-								return true // continue
-							}
+						if strings.HasPrefix(scope, cdn+"/") && strings.HasSuffix(scope, "/") {
+							return true // continue
 						}
 						importMap.SetScopeImports(scope, imports)
 						return true
@@ -130,12 +132,11 @@ func tidy(noSRI bool) (err error) {
 						specifiers = append(specifiers, imp.Specifier(true))
 					}
 					sort.Strings(specifiers)
-					addImports(importMap, specifiers, false, true, noSRI)
+					if !addImports(importMap, specifiers, false, true, noSRI) {
+						return fmt.Errorf("could not resolve imports")
+					}
 					buf.WriteString(importMap.FormatJSON(2))
 					buf.WriteString("\n  ")
-					if token == html.EndTagToken {
-						buf.Write(tokenizer.Raw())
-					}
 					continue
 				}
 			}

--- a/cli/command_tidy_test.go
+++ b/cli/command_tidy_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestTidyFailurePreservesHTML(t *testing.T) {
+	t.Chdir(t.TempDir())
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer cdn.Close()
+	source := fmt.Sprintf(`<head><script type="importmap">{"config":{"cdn":%q},"imports":{"react":%q}}</script></head>`, cdn.URL, cdn.URL+"/react@19.0.0/es2022/react.mjs")
+	if err := os.WriteFile("index.html", []byte(source), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := tidy(true); err == nil {
+		t.Fatal("expected resolution error")
+	}
+	got, err := os.ReadFile("index.html")
+	if err != nil || string(got) != source {
+		t.Fatalf("index.html changed on failure: %q, %v", got, err)
+	}
+}
+
+func TestTidyPreservesUnmanagedImports(t *testing.T) {
+	for _, imports := range []string{
+		`"react":"https://other.example/react@19.0.0/es2022/react.mjs"`,
+		`"custom":"https://esm.sh/react@19.0.0/es2022/react.mjs"`,
+		`"react":"https://esm.sh/react@19"`,
+	} {
+		t.Run(imports, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			source := `<head><script type="importmap">{"imports":{` + imports + `}}</script></head>`
+			if err := os.WriteFile("index.html", []byte(source), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := tidy(true); err != nil {
+				t.Fatal(err)
+			}
+			got, err := os.ReadFile("index.html")
+			if err != nil || string(got) != source {
+				t.Fatalf("unmanaged imports changed: %q, %v", got, err)
+			}
+		})
+	}
+}

--- a/cli/npm/bin/esm.sh
+++ b/cli/npm/bin/esm.sh
@@ -1,25 +1,31 @@
 #!/usr/bin/env node
 
 const { execFileSync } = require("child_process");
-const { createWriteStream, existsSync, readFileSync } = require("fs");
+const { chmodSync, createWriteStream, existsSync, readFileSync } = require("fs");
 const { Writable } = require("stream");
 const { join } = require("path");
 
 // On macOS/Linux, this file will be linked to "@esm.sh/cli-{os}-{arch}/bin/esm.sh" by the install script.
 // On Windows, or if the install script is interrupted, the binary path is resolved manually and executed.
 try {
-  execFileSync(resolveBinaryPath(), process.argv.slice(2), { stdio: 'inherit' })
+  execFileSync(resolveBinaryPath(), process.argv.slice(2), { stdio: "inherit" });
 } catch (err) {
-  downloadBinaryFromGitHub().then((res) => {
+  if (typeof err.status === "number" || err.signal) {
+    process.exit(err.status || 1);
+  }
+  downloadBinaryFromGitHub().then(async (res) => {
     const binPath = join(__dirname, "esm.sh" + (getBinExtension() || ".bin"));
-    res.pipeTo.pipeTo(Writable.toWeb(createWriteStream(binPath))).then(() => {
-      execFileSync(binPath, process.argv.slice(2), { stdio: 'inherit' });
-    });
+    await res.pipeTo(Writable.toWeb(createWriteStream(binPath)));
+    chmodSync(binPath, 0o755);
+    execFileSync(binPath, process.argv.slice(2), { stdio: "inherit" });
+  }).catch((err) => {
+    console.error("[esm.sh] Failed to run esm.sh:", err.message);
+    process.exit(err.status || 1);
   });
 }
 
 function resolveBinaryPath() {
-  const exeBinPath = join(__dirname, "esm.sh.exe");
+  const exeBinPath = join(__dirname, "esm.sh" + (getBinExtension() || ".bin"));
   if (existsSync(exeBinPath)) {
     return exeBinPath;
   }
@@ -33,8 +39,7 @@ function resolveBinaryPath() {
 
 async function downloadBinaryFromGitHub() {
   const pkgInfo = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf8"));
-  const [_, minor, patch] = pkgInfo.version.split(".");
-  const tag = "v" + minor + (Number(patch) > 0 ? "_" + patch : "");
+  const tag = "v" + pkgInfo.version;
   const url = `https://github.com/esm-dev/esm.sh/releases/download/${tag}/cli-${getOS()}-${getArch()}${getBinExtension()}.gz`;
   const res = await fetch(url);
   if (!res.ok) {
@@ -47,11 +52,9 @@ async function downloadBinaryFromGitHub() {
 function getOS() {
   switch (process.platform) {
     case "darwin":
-      return "darwin";
     case "linux":
-      return "linux";
     case "win32":
-      return "windows";
+      return process.platform;
     default:
       throw new Error(`Unsupported platform: ${process.platform}`);
   }
@@ -60,9 +63,8 @@ function getOS() {
 function getArch() {
   switch (process.arch) {
     case "arm64":
-      return "arm64";
     case "x64":
-      return "amd64";
+      return process.arch;
     default:
       throw new Error(`Unsupported architecture: ${process.arch}`);
   }

--- a/cli/npm/bootstrap.test.mjs
+++ b/cli/npm/bootstrap.test.mjs
@@ -1,0 +1,63 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { runInNewContext } from "node:vm";
+
+const source = readFileSync(new URL("bin/esm.sh", import.meta.url), "utf8");
+
+for (const platform of ["darwin", "linux", "win32"]) {
+  for (const arch of ["arm64", "x64"]) {
+    test(`bootstrap ${platform}-${arch}`, async () => {
+      const extension = platform === "win32" ? ".exe" : "";
+      const calls = [];
+      let installed = false;
+      const modules = {
+        child_process: { execFileSync: (path, args) => calls.push(["exec", path, args]) },
+        fs: {
+          existsSync: () => installed,
+          readFileSync: () => JSON.stringify({ version: "0.1.1" }),
+          createWriteStream: (path) => { calls.push(["write", path]); return {}; },
+          chmodSync: (path, mode) => calls.push(["chmod", path, mode]),
+        },
+        stream: { Writable: { toWeb: (stream) => stream } },
+        path: { join: (...parts) => parts.join("/") },
+      };
+      const require = Object.assign((id) => modules[id], {
+        resolve: (id) => { calls.push(["resolve", id]); throw new Error("missing optional package"); },
+      });
+      const context = {
+        require,
+        __dirname: "/package/bin",
+        process: { platform, arch, argv: ["node", "esm.sh", "--version"], exit: (code) => { throw new Error(`exit ${code}`); } },
+        console,
+        DecompressionStream: class {},
+        fetch: async (url) => {
+          calls.push(["fetch", url]);
+          return { ok: true, body: { pipeThrough: () => ({ pipeTo: async () => { installed = true; } }) } };
+        },
+      };
+      await runInNewContext(source, context);
+      const binPath = "/package/bin/esm.sh" + (extension || ".bin");
+      expect(calls).toContainEqual(["resolve", `@esm.sh/cli-${platform}-${arch}/bin/esm.sh${extension}`]);
+      expect(calls).toContainEqual(["fetch", `https://github.com/esm-dev/esm.sh/releases/download/v0.1.1/cli-${platform}-${arch}${extension}.gz`]);
+      expect(calls).toContainEqual(["chmod", binPath, 0o755]);
+      expect(calls).toContainEqual(["exec", binPath, ["--version"]]);
+      calls.length = 0;
+      await runInNewContext(source, { ...context });
+      expect(calls).toEqual([["exec", binPath, ["--version"]]]);
+    });
+  }
+}
+
+test("bootstrap preserves the native command exit status", () => {
+  const require = Object.assign((id) => ({
+    child_process: { execFileSync: () => { throw Object.assign(new Error("failed"), { status: 23 }); } },
+    fs: { existsSync: () => true },
+    stream: {},
+    path: { join: (...parts) => parts.join("/") },
+  })[id], { resolve: () => "/native" });
+  expect(() => runInNewContext(source, {
+    require,
+    __dirname: "/package/bin",
+    process: { platform: "linux", arch: "x64", argv: [], exit: (code) => { throw new Error(`exit ${code}`); } },
+  })).toThrow("exit 23");
+});

--- a/cli/npm/install.mjs
+++ b/cli/npm/install.mjs
@@ -1,6 +1,7 @@
 import { chmodSync, createWriteStream, existsSync, linkSync, readFileSync, statSync, unlinkSync } from "node:fs";
 import { createRequire } from "node:module";
 import { Writable } from "node:stream";
+import { fileURLToPath } from "node:url";
 
 const binExtension = process.platform === "win32" ? ".exe" : "";
 
@@ -41,8 +42,7 @@ function resolveBinaryPath() {
 
 async function downloadBinaryFromGitHub() {
   const pkgInfo = JSON.parse(readFileSync(toPackagePath("package.json"), "utf8"));
-  const [_, minor, patch] = pkgInfo.version.split(".");
-  const tag = "v" + minor + (Number(patch) > 0 ? "_" + patch : "");
+  const tag = "v" + pkgInfo.version;
   const url = `https://github.com/esm-dev/esm.sh/releases/download/${tag}/cli-${platform()}-${arch()}${binExtension}.gz`;
   const res = await fetch(url);
   if (!res.ok) {
@@ -74,7 +74,7 @@ function arch() {
 }
 
 function toPackagePath(filename) {
-  return new URL(filename, import.meta.url).pathname;
+  return fileURLToPath(new URL(filename, import.meta.url));
 }
 
 function chmodAddX(path) {

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -69,13 +69,14 @@ func lookupClosestFile(name string) (filename string, exists bool, err error) {
 		if err == nil && !fi.IsDir() {
 			return indexHtml, true, nil
 		}
-		if err != nil && os.IsExist(err) {
+		if err != nil && !os.IsNotExist(err) {
 			return "", false, err
 		}
-		dir = filepath.Dir(dir)
-		if dir == "/" || (os.PathSeparator == '\\' && len(dir) <= 3) {
+		parent := filepath.Dir(dir)
+		if parent == dir {
 			break
 		}
+		dir = parent
 	}
 	return filepath.Join(cwd, name), false, nil
 }

--- a/internal/importmap/importmap.go
+++ b/internal/importmap/importmap.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/esm-dev/esm.sh/internal/npm"
-	"github.com/ije/gox/set"
 	"github.com/ije/gox/term"
 	"github.com/ije/gox/utils"
 )
@@ -172,6 +171,17 @@ func (im *ImportMap) SetScopeImports(scope string, imports *Imports) {
 	im.lock.Unlock()
 }
 
+func (im *ImportMap) getOrCreateScopeImports(scope string) *Imports {
+	im.lock.Lock()
+	defer im.lock.Unlock()
+	imports, ok := im.scopes[scope]
+	if !ok {
+		imports = newImports(nil)
+		im.scopes[scope] = imports
+	}
+	return imports
+}
+
 // RangeScopes ranges over the scopes of the import map.
 func (im *ImportMap) RangeScopes(fn func(scope string, imports *Imports) bool) {
 	im.lock.RLock()
@@ -188,10 +198,6 @@ func (im *ImportMap) RangeScopes(fn func(scope string, imports *Imports) bool) {
 // This function follows the import maps specification:
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap
 func (im *ImportMap) Resolve(specifier string, referrer *url.URL) (string, bool) {
-	if im.baseUrl == nil {
-		im.baseUrl, _ = url.Parse("file:///")
-	}
-
 	var hash string
 	specifier, hash = utils.SplitByFirstByte(specifier, '#')
 	if hash != "" {
@@ -204,19 +210,21 @@ func (im *ImportMap) Resolve(specifier string, referrer *url.URL) (string, bool)
 		query = "?" + query
 	}
 
-	if referrer != nil && len(im.scopes) > 0 {
-		scopeKeys := make(ScopeKeys, 0, len(im.scopes))
-		for prefix := range im.scopes {
-			scopeKeys = append(scopeKeys, prefix)
-		}
+	if referrer != nil {
+		referrerURL := referrer.String()
+		var scopeKeys ScopeKeys
+		im.RangeScopes(func(scope string, _ *Imports) bool {
+			if strings.HasPrefix(referrerURL, scope) {
+				scopeKeys = append(scopeKeys, scope)
+			}
+			return true
+		})
 		sort.Sort(scopeKeys)
 		for _, scopeKey := range scopeKeys {
-			if strings.HasPrefix(referrer.String(), scopeKey) {
-				imports, _ := im.GetScopeImports(scopeKey)
-				ret, ok := im.resolveWith(specifier, imports)
-				if ok {
-					return ret + query + hash, true
-				}
+			imports, _ := im.GetScopeImports(scopeKey)
+			ret, ok := im.resolveWith(specifier, imports)
+			if ok {
+				return ret + query + hash, true
 			}
 		}
 	}
@@ -230,24 +238,22 @@ func (im *ImportMap) Resolve(specifier string, referrer *url.URL) (string, bool)
 }
 
 func (im *ImportMap) resolveWith(specifier string, imports *Imports) (string, bool) {
-	if len(imports.imports) == 0 {
-		return "", false
-	}
 	if url, ok := imports.Get(specifier); ok {
 		return normalizeUrl(im.baseUrl, url), true
 	}
 	// try to match tailing slash specifier
 	if strings.ContainsRune(specifier, '/') {
 		var matchedUrl string
+		var matchedLen int
 		imports.Range(func(k string, v string) bool {
-			if strings.HasSuffix(k, "/") && strings.HasPrefix(specifier, k) {
-				matchedUrl = normalizeUrl(im.baseUrl, v+specifier[len(k):])
-				return false
+			if len(k) > matchedLen && strings.HasSuffix(k, "/") && strings.HasPrefix(specifier, k) {
+				matchedUrl = v
+				matchedLen = len(k)
 			}
 			return true
 		})
-		if matchedUrl != "" {
-			return matchedUrl, true
+		if matchedLen > 0 {
+			return normalizeUrl(im.baseUrl, matchedUrl+specifier[matchedLen:]), true
 		}
 	}
 	return "", false
@@ -303,23 +309,18 @@ func (im *ImportMap) AddImportFromSpecifier(specifier string, noSRI bool) (warni
 
 // AddImport adds an import to the import map.
 func (im *ImportMap) AddImport(imp ImportMeta, noSRI bool) (warnings []string, errors []error) {
-	return im.addImport(set.New[string](), imp, false, nil, noSRI)
+	return im.addImport(new(sync.Map), imp, false, nil, noSRI)
 }
 
 // addImport adds an import to the import map.
-func (im *ImportMap) addImport(mark *set.Set[string], imp ImportMeta, indirect bool, targetImports *Imports, noSRI bool) (warnings []string, errors []error) {
+func (im *ImportMap) addImport(mark *sync.Map, imp ImportMeta, indirect bool, targetImports *Imports, noSRI bool) (warnings []string, errors []error) {
 	specifier := imp.Specifier(false)
-	if mark.Has(specifier) {
+	if _, loaded := mark.LoadOrStore(specifier, struct{}{}); loaded {
 		return
 	}
-	mark.Add(specifier)
 
 	cdnOrigin := im.cdnOrigin()
-	cdnScopeImportsMap, cdnScoped := im.GetScopeImports(cdnOrigin + "/")
-	if !cdnScoped {
-		cdnScopeImportsMap = &Imports{imports: map[string]string{}}
-		im.SetScopeImports(cdnOrigin+"/", cdnScopeImportsMap)
-	}
+	cdnScopeImportsMap := im.getOrCreateScopeImports(cdnOrigin + "/")
 
 	imports := im.Imports
 	if indirect {
@@ -396,9 +397,14 @@ func (im *ImportMap) addImport(mark *set.Set[string], imp ImportMeta, indirect b
 		if importsLen > 0 {
 			copy(allImports[peerImportsLen:], imp.Imports)
 		}
+		results := make([]struct {
+			warnings []string
+			errors   []error
+		}, len(allImports))
 		wg := sync.WaitGroup{}
 		for i, pathname := range allImports {
 			isPeer := i < peerImportsLen
+			result := &results[i]
 			wg.Go(func() {
 				if strings.HasPrefix(pathname, "/node/") {
 					// ignore node built-in modules
@@ -406,7 +412,7 @@ func (im *ImportMap) addImport(mark *set.Set[string], imp ImportMeta, indirect b
 				}
 				depImport, err := ParseEsmPath(pathname)
 				if err != nil {
-					errors = append(errors, err)
+					result.errors = append(result.errors, err)
 					return
 				}
 				// if the dependency is the same as the current import, use the version of the current import
@@ -436,30 +442,27 @@ func (im *ImportMap) addImport(mark *set.Set[string], imp ImportMeta, indirect b
 								return
 							}
 							if isPeer {
-								warnings = append(warnings, "incorrect peer dependency "+depImport.Name+"@"+addedImport.Version+term.Dim("(unmet "+depImport.Version+")"))
+								result.warnings = append(result.warnings, "incorrect peer dependency "+depImport.Name+"@"+addedImport.Version+term.Dim("(unmet "+depImport.Version+")"))
 								return
 							}
-							var ok bool
 							scope := cdnOrigin + "/" + imp.EsmSpecifier() + "/"
-							targetImports, ok = im.GetScopeImports(scope)
-							if !ok {
-								targetImports = newImports(nil)
-								im.SetScopeImports(scope, targetImports)
-							}
+							targetImports = im.getOrCreateScopeImports(scope)
 						}
 					}
 				}
 				meta, err := im.FetchImportMeta(depImport)
 				if err != nil {
-					errors = append(errors, err)
+					result.errors = append(result.errors, err)
 					return
 				}
-				warns, errs := im.addImport(mark, meta, !isPeer, targetImports, noSRI)
-				warnings = append(warnings, warns...)
-				errors = append(errors, errs...)
+				result.warnings, result.errors = im.addImport(mark, meta, !isPeer, targetImports, noSRI)
 			})
 		}
 		wg.Wait()
+		for _, result := range results {
+			warnings = append(warnings, result.warnings...)
+			errors = append(errors, result.errors...)
+		}
 	}
 
 	return
@@ -620,7 +623,10 @@ func newImports(imports map[string]string) *Imports {
 }
 
 func normalizeUrl(baseUrl *url.URL, path string) string {
-	if baseUrl != nil && (strings.HasPrefix(path, "./") || strings.HasPrefix(path, "../")) {
+	if strings.HasPrefix(path, "./") || strings.HasPrefix(path, "../") {
+		if baseUrl == nil {
+			baseUrl = &url.URL{Scheme: "file", Path: "/"}
+		}
 		return baseUrl.ResolveReference(&url.URL{Path: path}).String()
 	}
 	return path

--- a/internal/importmap/importmap_test.go
+++ b/internal/importmap/importmap_test.go
@@ -1,11 +1,128 @@
 package importmap
 
 import (
+	"fmt"
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 )
+
+func TestAddImportConcurrentResults(t *testing.T) {
+	const count = 64
+	im := Blank()
+	imp := ImportMeta{Import: Import{Name: "root", Version: "1.0.0"}}
+	for i := range count {
+		name := fmt.Sprintf("peer-%d", i)
+		im.Imports.Set(name, "https://esm.sh/"+name+"@1.0.0")
+		imp.PeerImports = append(imp.PeerImports, "/"+name+"@^2.0.0")
+		imp.Imports = append(imp.Imports, fmt.Sprintf("invalid-%d", i))
+	}
+	warnings, errors := im.AddImport(imp, true)
+	if len(warnings) != count || len(errors) != count {
+		t.Fatalf("got %d warnings and %d errors, want %d each", len(warnings), len(errors), count)
+	}
+	for i := range count {
+		if !strings.HasPrefix(warnings[i], fmt.Sprintf("incorrect peer dependency peer-%d@1.0.0", i)) {
+			t.Errorf("unexpected warning: %q", warnings[i])
+		}
+		if errors[i].Error() != fmt.Sprintf("invalid pathname or url: invalid-%d", i) {
+			t.Errorf("unexpected error: %v", errors[i])
+		}
+	}
+}
+
+func TestAddImportConcurrentScopes(t *testing.T) {
+	const count = 64
+	const origin = "https://importmap-concurrent.test"
+	im := Blank()
+	im.SetConfig(Config{CDN: origin})
+	imp := ImportMeta{Import: Import{Name: "root", Version: "1.0.0"}}
+	for i := range count {
+		name := fmt.Sprintf("dependency-%d", i)
+		im.Imports.Set(name, origin+"/"+name+"@1.0.0")
+		imp.Imports = append(imp.Imports, "/"+name+"@^2.0.0")
+		cacheKey := origin + "/" + name + "@^2.0.0?meta"
+		fetchCache.Store(cacheKey, ImportMeta{Import: Import{Name: name, Version: "2.0.0"}})
+		t.Cleanup(func() { fetchCache.Delete(cacheKey) })
+	}
+	warnings, errors := im.AddImport(imp, true)
+	if len(warnings) != 0 || len(errors) != 0 {
+		t.Fatalf("warnings %v, errors %v", warnings, errors)
+	}
+	imports, ok := im.GetScopeImports(origin + "/" + imp.EsmSpecifier() + "/")
+	if !ok || imports.Len() != count {
+		t.Fatalf("missing dependency scope entries: %v", imports)
+	}
+	for i := range count {
+		name := fmt.Sprintf("dependency-%d", i)
+		if got, ok := imports.Get(name); !ok || got != origin+"/"+name+"@2.0.0/es2022/"+name+".mjs" {
+			t.Errorf("incorrect scoped dependency %s: %q", name, got)
+		}
+	}
+}
+
+func TestResolveConcurrentScopes(t *testing.T) {
+	im := Blank()
+	im.Imports.Set("pkg", "./default.js")
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range 32 {
+		wg.Go(func() {
+			<-start
+			for j := range 8 {
+				if got, ok := im.Resolve("pkg", nil); !ok || got != "file:///default.js" {
+					t.Errorf("unexpected default import: %q", got)
+				}
+				scope := fmt.Sprintf("https://example.com/%d/%d/", i, j)
+				im.SetScopeImports(scope, newImports(map[string]string{"pkg": "./scoped.js"}))
+				referrer, _ := url.Parse(scope + "main.js")
+				if got, ok := im.Resolve("pkg", referrer); !ok || got != "file:///scoped.js" {
+					t.Errorf("unexpected scoped import: %q", got)
+				}
+			}
+		})
+	}
+	close(start)
+	wg.Wait()
+}
+
+func TestResolveLongestPrefix(t *testing.T) {
+	baseURL, _ := url.Parse("https://example.com/app/import-map.json")
+	im, err := Parse(baseURL, []byte(`{
+		"imports": {
+			"pkg/": "./default/",
+			"pkg/nested/": "./nested/",
+			"pkg/nested/exact": "./exact.js"
+		},
+		"scopes": {
+			"https://example.com/scoped/": {
+				"pkg/": "./scoped/",
+				"pkg/nested/": "./scoped-nested/"
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		specifier string
+		referrer  string
+		want      string
+	}{
+		{"pkg/nested/file.js?raw#section", "https://example.com/main.js", "https://example.com/app/nested/file.js?raw#section"},
+		{"pkg/nested/exact", "https://example.com/main.js", "https://example.com/app/exact.js"},
+		{"pkg/nested/file.js", "https://example.com/scoped/main.js", "https://example.com/app/scoped-nested/file.js"},
+	} {
+		referrer, _ := url.Parse(tc.referrer)
+		for range 100 {
+			if got, ok := im.Resolve(tc.specifier, referrer); !ok || got != tc.want {
+				t.Fatalf("Resolve(%q, %q) = %q, %v; want %q", tc.specifier, tc.referrer, got, ok, tc.want)
+			}
+		}
+	}
+}
 
 func TestAddPackages(t *testing.T) {
 	// 1. add imports

--- a/internal/storage/storage_fs.go
+++ b/internal/storage/storage_fs.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"crypto/rand"
 	"errors"
 	"io"
 	"os"
@@ -75,9 +76,12 @@ func (fs *fsStorage) Get(key string) (content io.ReadCloser, stat Stat, err erro
 	if err != nil {
 		return
 	}
-	content = file
-	stat, err = os.Stat(filename)
-	return
+	stat, err = file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, nil, err
+	}
+	return file, stat, nil
 }
 
 func (fs *fsStorage) Put(key string, content io.Reader) (err error) {
@@ -90,17 +94,20 @@ func (fs *fsStorage) Put(key string, content io.Reader) (err error) {
 		return
 	}
 
-	file, err := os.Create(filename)
+	file, err := os.OpenFile(filepath.Join(filepath.Dir(filename), ".storage-"+rand.Text()), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0666)
 	if err != nil {
 		return
 	}
+	defer os.Remove(file.Name())
 
 	_, err = io.Copy(file, content)
-	file.Close()
-	if err != nil {
-		os.Remove(filename) // clean up if error occurs
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
 	}
-	return
+	if err != nil {
+		return err
+	}
+	return os.Rename(file.Name(), filename)
 }
 
 func (fs *fsStorage) Delete(key string) (err error) {
@@ -178,11 +185,8 @@ func findFiles(root string, parentDir string) ([]string, error) {
 			if err != nil {
 				return nil, err
 			}
-			newFiles := make([]string, len(files)+len(subFiles))
-			copy(newFiles, files)
-			copy(newFiles[len(files):], subFiles)
-			files = newFiles
-		} else {
+			files = append(files, subFiles...)
+		} else if !strings.HasPrefix(name, ".storage-") {
 			files = append(files, path)
 		}
 	}

--- a/internal/storage/storage_fs_test.go
+++ b/internal/storage/storage_fs_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path"
@@ -9,6 +10,69 @@ import (
 
 	"github.com/ije/gox/crypto/rand"
 )
+
+func TestFSStoragePutKeepsCompleteContent(t *testing.T) {
+	fs, err := NewFSStorage(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = fs.Put("test.txt", bytes.NewBufferString("original")); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, writer := io.Pipe()
+	defer reader.Close()
+	defer writer.Close()
+	done := make(chan error, 1)
+	go func() { done <- fs.Put("test.txt", reader) }()
+	if _, err = writer.Write([]byte("partial")); err != nil {
+		t.Fatal(err)
+	}
+	keys, err := fs.List("")
+	if err != nil || len(keys) != 1 || keys[0] != "test.txt" {
+		t.Fatalf("List during write: keys %v, error %v", keys, err)
+	}
+	content, stat, err := fs.Get("test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(content)
+	content.Close()
+	if err != nil || string(data) != "original" || stat.Size() != 8 {
+		t.Fatalf("read during write: content %q, size %d, error %v", data, stat.Size(), err)
+	}
+
+	writeErr := errors.New("interrupted write")
+	writer.CloseWithError(writeErr)
+	if err = <-done; !errors.Is(err, writeErr) {
+		t.Fatalf("Put returned %v, want %v", err, writeErr)
+	}
+	content, _, err = fs.Get("test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err = io.ReadAll(content)
+	content.Close()
+	if err != nil || string(data) != "original" {
+		t.Fatalf("read after failed write: content %q, error %v", data, err)
+	}
+	keys, err = fs.List("")
+	if err != nil || len(keys) != 1 || keys[0] != "test.txt" {
+		t.Fatalf("List after failed write: keys %v, error %v", keys, err)
+	}
+	if err = fs.Put("test.txt", bytes.NewBufferString("replacement")); err != nil {
+		t.Fatal(err)
+	}
+	content, stat, err = fs.Get("test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err = io.ReadAll(content)
+	content.Close()
+	if err != nil || string(data) != "replacement" || stat.Size() != 11 {
+		t.Fatalf("read after replacement: content %q, size %d, error %v", data, stat.Size(), err)
+	}
+}
 
 func TestFSStorage(t *testing.T) {
 	root := path.Join(os.TempDir(), "storage_test_"+rand.Hex.String(8))

--- a/internal/storage/storage_s3.go
+++ b/internal/storage/storage_s3.go
@@ -2,12 +2,16 @@ package storage
 
 import (
 	"bytes"
+	"crypto/md5"
+	"encoding/base64"
 	"encoding/xml"
 	"errors"
+	"fmt"
 	"html"
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -61,7 +65,9 @@ func NewS3Storage(options *StorageOptions) (Storage, error) {
 }
 
 type s3ListResult struct {
-	Contents []struct {
+	IsTruncated           bool
+	NextContinuationToken string
+	Contents              []struct {
 		Key string
 	}
 }
@@ -173,13 +179,16 @@ func (s3 *s3Storage) Get(name string) (content io.ReadCloser, stat Stat, err err
 	if err != nil {
 		return
 	}
+	defer func() {
+		if err != nil {
+			resp.Body.Close()
+		}
+	}()
 	if resp.StatusCode == 404 {
-		defer resp.Body.Close()
 		err = ErrNotFound
 		return
 	}
 	if resp.StatusCode >= 400 {
-		defer resp.Body.Close()
 		return nil, nil, parseS3Error(resp)
 	}
 	contentLengthHeader := resp.Header.Get("Content-Length")
@@ -210,6 +219,7 @@ func (s3 *s3Storage) Get(name string) (content io.ReadCloser, stat Stat, err err
 		cacheKey := s3.fsCacheKey(name)
 		pr, pw := io.Pipe()
 		go func() {
+			defer resp.Body.Close()
 			unlock := s3.fsCacheLock.Lock(name)
 			defer unlock()
 			_, err := s3.fsCache.Stat(cacheKey)
@@ -220,7 +230,6 @@ func (s3 *s3Storage) Get(name string) (content io.ReadCloser, stat Stat, err err
 			}
 			err = s3.fsCache.Put(cacheKey, io.TeeReader(resp.Body, pw))
 			pw.CloseWithError(err)
-			resp.Body.Close()
 		}()
 		content = pr
 	} else {
@@ -319,26 +328,35 @@ func (s3 *s3Storage) List(prefix string) (keys []string, err error) {
 	if prefix != "" {
 		query.Set("prefix", prefix)
 	}
-	req, _ := http.NewRequest("GET", s3.apiEndpoint+"?"+query.Encode(), nil)
-	s3.sign(req)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return
+	keys = []string{}
+	for {
+		req, _ := http.NewRequest("GET", s3.apiEndpoint+"?"+query.Encode(), nil)
+		s3.sign(req)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return keys, err
+		}
+		var ret s3ListResult
+		if resp.StatusCode >= 400 {
+			err = parseS3Error(resp)
+		} else {
+			err = xml.NewDecoder(resp.Body).Decode(&ret)
+		}
+		resp.Body.Close()
+		if err != nil {
+			return keys, err
+		}
+		for _, content := range ret.Contents {
+			keys = append(keys, content.Key)
+		}
+		if !ret.IsTruncated {
+			return keys, nil
+		}
+		if ret.NextContinuationToken == "" || ret.NextContinuationToken == query.Get("continuation-token") {
+			return keys, errors.New("invalid S3 continuation token")
+		}
+		query.Set("continuation-token", ret.NextContinuationToken)
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 400 {
-		return nil, parseS3Error(resp)
-	}
-	var ret s3ListResult
-	err = xml.NewDecoder(resp.Body).Decode(&ret)
-	if err != nil {
-		return
-	}
-	keys = make([]string, len(ret.Contents))
-	for i, content := range ret.Contents {
-		keys[i] = content.Key
-	}
-	return
 }
 
 func (s3 *s3Storage) DeleteAll(prefix string) (deletedKeys []string, err error) {
@@ -355,32 +373,42 @@ func (s3 *s3Storage) DeleteAll(prefix string) (deletedKeys []string, err error) 
 	if len(keysToDelete) == 0 {
 		return []string{}, nil
 	}
-	buf := new(bytes.Buffer)
-	buf.WriteString("<Delete>")
-	for _, key := range keysToDelete {
-		buf.WriteString("<Object><Key>")
-		buf.WriteString(html.EscapeString(key))
-		buf.WriteString("</Key></Object>")
-	}
-	buf.WriteString("</Delete>")
-	req, _ := http.NewRequest("POST", s3.apiEndpoint+"?delete", buf)
-	s3.sign(req)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 400 {
-		return nil, parseS3Error(resp)
-	}
-	var ret s3DeleteResult
-	err = xml.NewDecoder(resp.Body).Decode(&ret)
-	if err != nil {
-		return
-	}
-	deletedKeys = make([]string, len(ret.Deleted))
-	for i, deleted := range ret.Deleted {
-		deletedKeys[i] = deleted.Key
+	for batch := range slices.Chunk(keysToDelete, 1000) {
+		buf := new(bytes.Buffer)
+		buf.WriteString("<Delete>")
+		for _, key := range batch {
+			buf.WriteString("<Object><Key>")
+			buf.WriteString(html.EscapeString(key))
+			buf.WriteString("</Key></Object>")
+		}
+		buf.WriteString("</Delete>")
+		checksum := md5.Sum(buf.Bytes())
+		req, _ := http.NewRequest("POST", s3.apiEndpoint+"?delete", buf)
+		req.Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(checksum[:]))
+		s3.sign(req)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return deletedKeys, err
+		}
+		var ret s3DeleteResult
+		if resp.StatusCode >= 400 {
+			err = parseS3Error(resp)
+		} else {
+			err = xml.NewDecoder(resp.Body).Decode(&ret)
+		}
+		resp.Body.Close()
+		if err != nil {
+			return deletedKeys, err
+		}
+		for _, deleted := range ret.Deleted {
+			deletedKeys = append(deletedKeys, deleted.Key)
+		}
+		for _, failure := range ret.Error {
+			err = errors.Join(err, fmt.Errorf("failed to delete %q: %w", failure.Key, s3Error{Code: failure.Code, Message: failure.Message}))
+		}
+		if err != nil {
+			return deletedKeys, err
+		}
 	}
 	return
 }

--- a/internal/storage/storage_s3_test.go
+++ b/internal/storage/storage_s3_test.go
@@ -2,10 +2,99 @@ package storage
 
 import (
 	"bytes"
+	"crypto/md5"
+	"encoding/base64"
+	"encoding/xml"
+	"fmt"
 	"io"
+	"net/http"
 	"os"
+	"slices"
+	"strings"
 	"testing"
+	"time"
 )
+
+type s3TestTransport func(*http.Request) (*http.Response, error)
+
+func (transport s3TestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return transport(req)
+}
+
+type s3TestBody struct {
+	io.Reader
+	closed chan struct{}
+}
+
+func (body *s3TestBody) Close() error {
+	close(body.closed)
+	return nil
+}
+
+func TestS3StorageGetClosesInvalidResponse(t *testing.T) {
+	for _, headers := range []http.Header{
+		{},
+		{"Content-Length": {"invalid"}},
+		{"Content-Length": {"4"}},
+		{"Content-Length": {"4"}, "Last-Modified": {"invalid"}},
+	} {
+		t.Run(headers.Get("Content-Length")+"/"+headers.Get("Last-Modified"), func(t *testing.T) {
+			body := &s3TestBody{Reader: strings.NewReader("data"), closed: make(chan struct{})}
+			client := http.DefaultClient
+			t.Cleanup(func() { http.DefaultClient = client })
+			http.DefaultClient = &http.Client{Transport: s3TestTransport(func(*http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: 200, Header: headers, Body: body}, nil
+			})}
+			s3 := &s3Storage{apiEndpoint: "https://storage.test"}
+			if _, _, err := s3.Get("test.txt"); err == nil {
+				t.Fatal("expected a metadata error")
+			}
+			select {
+			case <-body.closed:
+			default:
+				t.Fatal("response body was not closed")
+			}
+		})
+	}
+}
+
+func TestS3StorageGetClosesResponseWhenCacheIsFilled(t *testing.T) {
+	cache, err := NewFSStorage(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := &s3TestBody{Reader: strings.NewReader("data"), closed: make(chan struct{})}
+	client := http.DefaultClient
+	t.Cleanup(func() { http.DefaultClient = client })
+	http.DefaultClient = &http.Client{Transport: s3TestTransport(func(*http.Request) (*http.Response, error) {
+		if err := cache.Put("test.txt", strings.NewReader("data")); err != nil {
+			return nil, err
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Header: http.Header{
+				"Content-Length": {"4"},
+				"Last-Modified":  {time.Now().UTC().Format(http.TimeFormat)},
+			},
+			Body: body,
+		}, nil
+	})}
+	s3 := &s3Storage{apiEndpoint: "https://storage.test", fsCache: cache.(*fsStorage)}
+	content, _, err := s3.Get("test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer content.Close()
+	data, err := io.ReadAll(content)
+	if err != nil || string(data) != "data" {
+		t.Fatalf("content %q, error %v", data, err)
+	}
+	select {
+	case <-body.closed:
+	case <-time.After(time.Second):
+		t.Fatal("response body was not closed")
+	}
+}
 
 func TestS3StorageFSCacheKey(t *testing.T) {
 	s3 := &s3Storage{}
@@ -17,6 +106,148 @@ func TestS3StorageFSCacheKey(t *testing.T) {
 	}
 	if got = s3.fsCacheKey("v135/react@19.2.0/esnext/react.mjs"); got != "v135/react@19.2.0/esnext/react.mjs" {
 		t.Fatalf("invalid cache key %q", got)
+	}
+}
+
+func TestS3StorageListPagination(t *testing.T) {
+	client := http.DefaultClient
+	t.Cleanup(func() { http.DefaultClient = client })
+	const token = "next+/=&?"
+	var previous *s3TestBody
+	requests := 0
+	http.DefaultClient = &http.Client{Transport: s3TestTransport(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if previous != nil {
+			select {
+			case <-previous.closed:
+			default:
+				t.Error("previous page body was not closed")
+			}
+		}
+		if req.URL.Query().Get("prefix") != "test/" || req.URL.Query().Get("list-type") != "2" {
+			t.Fatalf("unexpected list query: %s", req.URL.RawQuery)
+		}
+		var body string
+		switch requests {
+		case 1:
+			body = `<ListBucketResult><Contents><Key>test/a</Key></Contents><IsTruncated>true</IsTruncated><NextContinuationToken>next+/=&amp;?</NextContinuationToken></ListBucketResult>`
+		case 2:
+			if req.URL.Query().Get("continuation-token") != token {
+				t.Fatalf("unexpected continuation token: %s", req.URL.RawQuery)
+			}
+			body = `<ListBucketResult><Contents><Key>test/b</Key></Contents><IsTruncated>false</IsTruncated></ListBucketResult>`
+		default:
+			t.Fatal("unexpected extra list request")
+		}
+		previous = &s3TestBody{Reader: strings.NewReader(body), closed: make(chan struct{})}
+		return &http.Response{StatusCode: 200, Body: previous}, nil
+	})}
+	s3 := &s3Storage{apiEndpoint: "https://storage.test"}
+	keys, err := s3.List("test/")
+	if err != nil || !slices.Equal(keys, []string{"test/a", "test/b"}) {
+		t.Fatalf("list = %v, %v", keys, err)
+	}
+	select {
+	case <-previous.closed:
+	default:
+		t.Fatal("last page body was not closed")
+	}
+}
+
+func TestS3StorageListInvalidPagination(t *testing.T) {
+	for _, token := range []string{"", "repeated"} {
+		t.Run(token, func(t *testing.T) {
+			client := http.DefaultClient
+			t.Cleanup(func() { http.DefaultClient = client })
+			requests := 0
+			http.DefaultClient = &http.Client{Transport: s3TestTransport(func(*http.Request) (*http.Response, error) {
+				requests++
+				if requests > 2 {
+					t.Fatal("pagination did not stop on an invalid token")
+				}
+				body := "<ListBucketResult><IsTruncated>true</IsTruncated><NextContinuationToken>" + token + "</NextContinuationToken></ListBucketResult>"
+				return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}, nil
+			})}
+			s3 := &s3Storage{apiEndpoint: "https://storage.test"}
+			if _, err := s3.List("test/"); err == nil {
+				t.Fatal("expected invalid pagination to fail")
+			}
+		})
+	}
+}
+
+func TestS3StorageDeleteAllBatches(t *testing.T) {
+	client := http.DefaultClient
+	t.Cleanup(func() { http.DefaultClient = client })
+	keys := make([]string, 2005)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("test/%04d", i)
+	}
+	var batches []int
+	var deleted []string
+	http.DefaultClient = &http.Client{Transport: s3TestTransport(func(req *http.Request) (*http.Response, error) {
+		var response strings.Builder
+		if req.Method == http.MethodGet {
+			start := 0
+			if _, err := fmt.Sscanf(req.URL.Query().Get("continuation-token"), "%d", &start); err != nil && req.URL.Query().Has("continuation-token") {
+				t.Fatal(err)
+			}
+			end := min(start+1000, len(keys))
+			response.WriteString("<ListBucketResult>")
+			for _, key := range keys[start:end] {
+				fmt.Fprintf(&response, "<Contents><Key>%s</Key></Contents>", key)
+			}
+			if end < len(keys) {
+				fmt.Fprintf(&response, "<IsTruncated>true</IsTruncated><NextContinuationToken>%d</NextContinuationToken>", end)
+			}
+			response.WriteString("</ListBucketResult>")
+		} else {
+			if req.Method != http.MethodPost || !req.URL.Query().Has("delete") {
+				t.Fatalf("unexpected delete request: %s %s", req.Method, req.URL)
+			}
+			data, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			checksum := md5.Sum(data)
+			if req.Header.Get("Content-MD5") != base64.StdEncoding.EncodeToString(checksum[:]) {
+				t.Error("missing or incorrect delete body checksum")
+			}
+			var body struct{ Object []struct{ Key string } }
+			if err := xml.Unmarshal(data, &body); err != nil {
+				t.Fatal(err)
+			}
+			batches = append(batches, len(body.Object))
+			response.WriteString("<DeleteResult>")
+			for _, object := range body.Object {
+				deleted = append(deleted, object.Key)
+				fmt.Fprintf(&response, "<Deleted><Key>%s</Key></Deleted>", object.Key)
+			}
+			response.WriteString("</DeleteResult>")
+		}
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(response.String()))}, nil
+	})}
+	s3 := &s3Storage{apiEndpoint: "https://storage.test"}
+	got, err := s3.DeleteAll("test/")
+	if err != nil || !slices.Equal(got, keys) || !slices.Equal(deleted, keys) || !slices.Equal(batches, []int{1000, 1000, 5}) {
+		t.Fatalf("delete: %d results, %d requested keys, batches %v, error %v", len(got), len(deleted), batches, err)
+	}
+}
+
+func TestS3StorageDeleteAllPartialError(t *testing.T) {
+	client := http.DefaultClient
+	t.Cleanup(func() { http.DefaultClient = client })
+	http.DefaultClient = &http.Client{Transport: s3TestTransport(func(req *http.Request) (*http.Response, error) {
+		body := `<ListBucketResult><Contents><Key>test/a</Key></Contents><Contents><Key>test/b</Key></Contents></ListBucketResult>`
+		if req.Method == http.MethodPost {
+			body = `<DeleteResult><Deleted><Key>test/a</Key></Deleted><Error><Key>test/b</Key><Code>AccessDenied</Code><Message>Access Denied</Message></Error></DeleteResult>`
+		}
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}, nil
+	})}
+	s3 := &s3Storage{apiEndpoint: "https://storage.test"}
+	deleted, err := s3.DeleteAll("test/")
+	if !slices.Equal(deleted, []string{"test/a"}) || err == nil || !strings.Contains(err.Error(), "test/b") || !strings.Contains(err.Error(), "AccessDenied") {
+		t.Fatalf("partial delete = %v, %v", deleted, err)
 	}
 }
 

--- a/server/build.go
+++ b/server/build.go
@@ -203,7 +203,7 @@ func (ctx *BuildContext) buildPath() {
 
 	esm := ctx.esmPath
 	if ctx.target == "types" {
-		if strings.HasSuffix(esm.SubPath, ".d.ts") {
+		if endsWith(esm.SubPath, ".d.ts", ".d.mts", ".d.cts") {
 			ctx.path = fmt.Sprintf(
 				"/%s%s/%s%s",
 				asteriskPrefix,
@@ -275,7 +275,7 @@ func (ctx *BuildContext) buildModule(analyzeMode bool) (meta *BuildMeta, include
 		}
 		meta = &BuildMeta{
 			TypesOnly: true,
-			Dts:       "/" + ctx.esmPath.PackageId() + entry.types[1:],
+			Dts:       "/" + ctx.esmPath.PackageId() + "/" + ctx.getBuildArgsPrefix(true) + strings.TrimPrefix(entry.types, "./"),
 		}
 		return
 	}
@@ -1573,7 +1573,7 @@ func (ctx *BuildContext) buildTypes() (ret *BuildMeta, err error) {
 		return
 	}
 
-	ret = &BuildMeta{Dts: "/" + ctx.esmPath.PackageId() + dts[1:]}
+	ret = &BuildMeta{Dts: "/" + ctx.esmPath.PackageId() + "/" + ctx.getBuildArgsPrefix(true) + strings.TrimPrefix(dts, "./")}
 	return
 }
 

--- a/server/build_analyzer.go
+++ b/server/build_analyzer.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bufio"
-	"io"
 	"os"
 	"path"
 	"strconv"
@@ -51,40 +50,31 @@ func (ctx *BuildContext) analyzeSplitting() {
 			}
 			defer f.Close()
 
-			var a []string
-			var i int
-			var r = bufio.NewReader(f)
-			for {
-				line, readErr := r.ReadString('\n')
-				if readErr == nil || readErr == io.EOF {
-					line = strings.TrimSpace(line)
-					if line != "" {
-						if a == nil {
-							n, e := strconv.Atoi(line)
-							if e != nil {
-								break
-							}
-							a = make([]string, n+1)
-						}
-						a[i] = line
-						i++
+			r := bufio.NewScanner(f)
+			if !r.Scan() {
+				return false
+			}
+			n, err := strconv.Atoi(strings.TrimSpace(r.Text()))
+			if err != nil || n < 0 {
+				return false
+			}
+			var modules []string
+			for r.Scan() {
+				if module := strings.TrimSpace(r.Text()); module != "" {
+					if len(modules) == n {
+						return false
 					}
-				}
-				if readErr != nil {
-					break
+					modules = append(modules, module)
 				}
 			}
-			if len(a) > 0 {
-				n, e := strconv.Atoi(a[0])
-				if e == nil && n <= len(a)-1 {
-					ctx.splitting = set.NewReadOnly(a[1 : n+1]...)
-					if DEBUG {
-						ctx.logger.Debugf("build(%s): splitting.txt found with %d shared modules", ctx.esmPath.String(), ctx.splitting.Len())
-					}
-					return true
-				}
+			if r.Err() != nil || len(modules) != n {
+				return false
 			}
-			return false
+			ctx.splitting = set.NewReadOnly(modules...)
+			if DEBUG {
+				ctx.logger.Debugf("build(%s): splitting.txt found with %d shared modules", ctx.esmPath.String(), ctx.splitting.Len())
+			}
+			return true
 		}
 
 		// check if the splitting has been analyzed

--- a/server/build_analyzer_test.go
+++ b/server/build_analyzer_test.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/esm-dev/esm.sh/internal/npm"
+	"github.com/ije/gox/log"
+)
+
+func TestAnalyzeSplittingInvalidCache(t *testing.T) {
+	for _, contents := range []string{"-1", "999999999999999999", "2\none.js", "0\none.js"} {
+		t.Run(contents, func(t *testing.T) {
+			wd := t.TempDir()
+			pkgDir := filepath.Join(wd, "node_modules", "example")
+			if err := os.MkdirAll(pkgDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			for _, filename := range []string{"a.js", "b.js"} {
+				if err := os.WriteFile(filepath.Join(pkgDir, filename), []byte("export const value = 1;"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			cachePath := filepath.Join(wd, "splitting.txt")
+			if err := os.WriteFile(cachePath, []byte(contents), 0644); err != nil {
+				t.Fatal(err)
+			}
+			logger, err := log.New("")
+			if err != nil {
+				t.Fatal(err)
+			}
+			logger.SetOutput(io.Discard)
+			ctx := &BuildContext{
+				wd: wd, target: "es2022", logger: logger,
+				esmPath: EsmPath{PkgName: "example", PkgVersion: "1.0.0"},
+				pkgJson: &npm.PackageJSON{
+					Name: "example", Version: "1.0.0", Type: "module",
+					Exports: npm.NewJSONObject([]string{"./a", "./b"}, map[string]any{"./a": "./a.js", "./b": "./b.js"}),
+				},
+			}
+			ctx.analyzeSplitting()
+			data, err := os.ReadFile(cachePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(data) != "0" {
+				t.Fatalf("invalid cache was not rebuilt: %q", data)
+			}
+		})
+	}
+}

--- a/server/build_args.go
+++ b/server/build_args.go
@@ -168,6 +168,9 @@ func resolveBuildArgs(npmrc *NpmRC, installDir string, args *BuildArgs, esm EsmP
 			}
 			if args.External.Len() > 0 {
 				for _, name := range args.External.Values() {
+					if strings.HasPrefix(name, "node:") || (name == esm.PkgName && esm.SubPath != "") {
+						continue
+					}
 					if !deps.Has(name) {
 						return nil, false, nil
 					}

--- a/server/build_args_test.go
+++ b/server/build_args_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ije/gox/set"
@@ -48,5 +50,33 @@ func TestEncodeBuildArgs(t *testing.T) {
 	}
 	if !args.IgnoreAnnotations {
 		t.Fatal("ignoreAnnotations should be true")
+	}
+}
+
+func TestResolveBuildArgsExternalWithoutWalkingDeps(t *testing.T) {
+	wd := t.TempDir()
+	for name, contents := range map[string]string{
+		"example": `{"name":"example","dependencies":{"broken":"1.0.0"}}`,
+		"broken":  `invalid package metadata`,
+	} {
+		pkgDir := filepath.Join(wd, "node_modules", name)
+		if err := os.MkdirAll(pkgDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(contents), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, external := range []string{"node:fs", "example"} {
+		t.Run(external, func(t *testing.T) {
+			args := BuildArgs{External: *set.NewReadOnly(external)}
+			err := resolveBuildArgs(nil, wd, &args, EsmPath{PkgName: "example", PkgVersion: "1.0.0", SubPath: "sub"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !args.External.Has(external) {
+				t.Fatalf("lost external %q", external)
+			}
+		})
 	}
 }

--- a/server/build_test.go
+++ b/server/build_test.go
@@ -85,3 +85,51 @@ func TestBuildModuleJSONPathTraversal(t *testing.T) {
 		t.Fatalf("unexpected module output: %s", data)
 	}
 }
+
+func TestBuildTypesArgs(t *testing.T) {
+	for _, filename := range []string{"index.d.ts", "index.d.mts", "index.d.cts"} {
+		t.Run(filename, func(t *testing.T) {
+			wd := t.TempDir()
+			pkgDir := filepath.Join(wd, "node_modules", "example")
+			if err := os.MkdirAll(pkgDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(pkgDir, filename), []byte("export {};"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			fs, err := storage.NewFSStorage(filepath.Join(wd, "storage"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx := &BuildContext{
+				wd: wd, target: "types", storage: fs,
+				esmPath: EsmPath{PkgName: "example", PkgVersion: "1.0.0", SubPath: filename},
+				pkgJson: &npm.PackageJSON{Name: "example", Version: "1.0.0", Types: "./" + filename},
+				args:    BuildArgs{Conditions: []string{"custom"}},
+			}
+			want := "/example@1.0.0/" + ctx.getBuildArgsPrefix(true) + filename
+			if got := ctx.Path(); got != want {
+				t.Errorf("build path = %q, want %q", got, want)
+			}
+			meta, err := ctx.buildTypes()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if meta.Dts != want {
+				t.Errorf("types metadata = %q, want %q", meta.Dts, want)
+			}
+			if _, err := fs.Stat(normalizeSavePath("types" + want)); err != nil {
+				t.Fatalf("missing transformed types: %v", err)
+			}
+			ctx.target = "es2022"
+			ctx.path = ""
+			meta, _, err = ctx.buildModule(false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if meta.Dts != want {
+				t.Errorf("types-only module metadata = %q, want %q", meta.Dts, want)
+			}
+		})
+	}
+}

--- a/server/cache.go
+++ b/server/cache.go
@@ -110,17 +110,14 @@ func withLRUCache[T any](key string, fetch func() (T, error)) (data T, err error
 }
 
 func gc(now time.Time) {
-	expKeys := []string{}
+	expires := now.UnixMilli()
 	cacheStore.Range(func(key, value any) bool {
 		item := value.(*cacheItem)
-		if item.exp > 0 && item.exp < now.UnixMilli() {
-			expKeys = append(expKeys, key.(string))
+		if item.exp > 0 && item.exp < expires {
+			cacheStore.CompareAndDelete(key, value)
 		}
 		return true
 	})
-	for _, key := range expKeys {
-		cacheStore.Delete(key)
-	}
 }
 
 func init() {

--- a/server/cjs_module_lexer.go
+++ b/server/cjs_module_lexer.go
@@ -203,8 +203,10 @@ func installCjsModuleLexerContext(ctx context.Context) (err error) {
 	if DEBUG {
 		localBuild := "../cjs-module-lexer/target/release/native"
 		if existsFile(localBuild) {
-			ensureDir(installDir)
-			_, err = utils.CopyFile(localBuild, installPath)
+			if err = ensureDir(installDir); err != nil {
+				return err
+			}
+			_, err = utils.CopyFile(localBuild, path.Join(installDir, "cjs-module-lexer-dev"))
 			if err == nil {
 				cjsModuleLexerVersion = "dev"
 			}
@@ -245,15 +247,26 @@ func installCjsModuleLexerContext(ctx context.Context) (err error) {
 	}
 	defer gr.Close()
 
-	ensureDir(installDir)
-	f, err := os.OpenFile(installPath, os.O_CREATE|os.O_WRONLY, 0755)
+	if err = ensureDir(installDir); err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(installDir, ".cjs-module-lexer-*")
 	if err != nil {
 		return fmt.Errorf("failed to create cjs-module-lexer: %v", err)
 	}
+	defer os.Remove(f.Name())
 	defer f.Close()
 
-	_, err = io.Copy(f, &contextReader{ctx: ctx, reader: gr})
-	return
+	if _, err = io.Copy(f, &contextReader{ctx: ctx, reader: gr}); err != nil {
+		return err
+	}
+	if err = f.Chmod(0755); err != nil {
+		return err
+	}
+	if err = f.Close(); err != nil {
+		return err
+	}
+	return os.Rename(f.Name(), installPath)
 }
 
 func getCjsModuleLexerDownloadURL() (string, error) {

--- a/server/cjs_module_lexer_test.go
+++ b/server/cjs_module_lexer_test.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallCjsModuleLexerRetry(t *testing.T) {
+	oldClient, oldConfig := http.DefaultClient, config
+	config = &Config{WorkDir: t.TempDir()}
+	t.Cleanup(func() { http.DefaultClient, config = oldClient, oldConfig })
+	var compressed bytes.Buffer
+	w := gzip.NewWriter(&compressed)
+	const binary = "lexer executable"
+	if _, err := io.WriteString(w, binary); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	requests := 0
+	http.DefaultClient = &http.Client{Transport: ghTestTransport(func(r *http.Request) (*http.Response, error) {
+		requests++
+		data := compressed.Bytes()
+		if requests == 1 {
+			data = data[:len(data)-3]
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(bytes.NewReader(data)), Header: make(http.Header)}, nil
+	})}
+	filename := filepath.Join(config.WorkDir, "bin", "cjs-module-lexer-"+cjsModuleLexerVersion)
+	if err := installCjsModuleLexerContext(context.Background()); err == nil {
+		t.Fatal("expected truncated download to fail")
+	}
+	if _, err := os.Stat(filename); !os.IsNotExist(err) {
+		t.Fatalf("failed download left an executable: %v", err)
+	}
+	if err := installCjsModuleLexerContext(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requests != 2 || string(data) != binary {
+		t.Fatalf("retry did not install the binary: requests=%d, contents=%q", requests, data)
+	}
+	info, err := os.Stat(filename)
+	if err != nil || info.Mode()&0111 == 0 {
+		t.Fatalf("installed binary is not executable: %v", err)
+	}
+}
+
+func TestInstallCjsModuleLexerDev(t *testing.T) {
+	if !DEBUG {
+		t.Skip("requires debug build")
+	}
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "esm.sh")
+	nativeDir := filepath.Join(root, "cjs-module-lexer", "target", "release")
+	for _, dir := range []string{projectDir, nativeDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Chdir(projectDir)
+	if err := os.WriteFile(filepath.Join(nativeDir, "native"), []byte("dev lexer"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	oldConfig, oldVersion := config, cjsModuleLexerVersion
+	config = &Config{WorkDir: t.TempDir()}
+	t.Cleanup(func() { config, cjsModuleLexerVersion = oldConfig, oldVersion })
+	if err := installCjsModuleLexerContext(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(config.WorkDir, "bin", "cjs-module-lexer-"+cjsModuleLexerVersion))
+	if err != nil || string(data) != "dev lexer" {
+		t.Fatalf("dev lexer is not at the execution path: %q, %v", data, err)
+	}
+}

--- a/server/loader.go
+++ b/server/loader.go
@@ -14,9 +14,8 @@ import (
 )
 
 type LoaderOutput struct {
-	Lang  string `json:"lang"`
-	Code  string `json:"code"`
-	Error string `json:"error"`
+	Lang string
+	Code string
 }
 
 func runLoaderContext(ctx context.Context, loaderJsPath string, filename string, code string) (out *LoaderOutput, err error) {

--- a/server/npmrc.go
+++ b/server/npmrc.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"archive/tar"
-	"bytes"
 	"compress/gzip"
 	"context"
 	"encoding/base64"
@@ -16,7 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -210,24 +208,19 @@ CHECK:
 			version = "latest"
 			goto CHECK
 		}
-		vs := make([]*semver.Version, len(metadata.Versions))
-		i := 0
+		var latest *semver.Version
+		includePrerelease := strings.ContainsRune(version, '-')
 		for v := range metadata.Versions {
-			if !strings.ContainsRune(version, '-') && strings.ContainsRune(v, '-') {
+			if !includePrerelease && strings.ContainsRune(v, '-') {
 				continue
 			}
 			sv, err := semver.NewVersion(v)
-			if err == nil && c.Check(sv) {
-				vs[i] = sv
-				i++
+			if err == nil && c.Check(sv) && (latest == nil || sv.GreaterThan(latest)) {
+				latest = sv
 			}
 		}
-		if i > 0 {
-			vs = vs[:i]
-			if i > 1 {
-				sort.Sort(semver.Collection(vs))
-			}
-			return vs[i-1].String(), nil
+		if latest != nil {
+			return latest.Original(), nil
 		}
 	}
 	return "", fmt.Errorf("version %s not found", version)
@@ -296,7 +289,7 @@ func invalidateDistTagCacheIfNewer(pkgName string, version string) {
 		return
 	}
 	key := "npm:" + pkgName + "@latest"
-	v, ok := getCacheItem(key)
+	v, _ := getCacheItem(key)
 	latest, ok := v.(*npm.PackageJSON)
 	if !ok || !semverLessThan(latest.Version, version) {
 		return
@@ -370,8 +363,7 @@ func (npmrc *NpmRC) installPackageContext(ctx context.Context, pkg npm.Package) 
 		err = ghInstallContext(ctx, installDir, pkg.Name, pkg.Version)
 		// ensure 'package.json' file if not exists after installing from github
 		if err == nil && !existsFile(packageJsonPath) {
-			buf := bytes.NewBuffer(nil)
-			buf.WriteString(`{"name":"` + pkg.Name + `","version":"` + pkg.Version + `"`)
+			packageData := map[string]any{"name": pkg.Name, "version": pkg.Version}
 			var denoJson *npm.PackageJSON
 			if deonJsonPath := filepath.Join(installDir, "node_modules", pkg.Name, "deno.json"); existsFile(deonJsonPath) {
 				var raw npm.PackageJSONRaw
@@ -388,32 +380,23 @@ func (npmrc *NpmRC) installPackageContext(ctx context.Context, pkg npm.Package) 
 				}
 			}
 			if denoJson != nil {
-				if denoJson.Imports.Len() > 0 {
-					buf.WriteString(`,"imports":{`)
-					for _, k := range denoJson.Imports.Keys() {
-						v, _ := denoJson.Imports.Get(k)
-						if s, ok := v.(string); ok {
-							buf.WriteString(`"` + k + `":"` + s + `",`)
+				for field, object := range map[string]npm.JSONObject{"imports": denoJson.Imports, "exports": denoJson.Exports} {
+					values := map[string]string{}
+					for key, value := range object.Values() {
+						if s, ok := value.(string); ok {
+							values[key] = s
 						}
 					}
-					buf.Truncate(buf.Len() - 1)
-					buf.WriteByte('}')
-				}
-				if denoJson.Exports.Len() > 0 {
-					buf.WriteString(`,"exports":{`)
-					for _, k := range denoJson.Exports.Keys() {
-						if v, ok := denoJson.Exports.Get(k); ok {
-							if s, ok := v.(string); ok {
-								buf.WriteString(`"` + k + `":"` + s + `",`)
-							}
-						}
+					if len(values) > 0 {
+						packageData[field] = values
 					}
-					buf.Truncate(buf.Len() - 1)
-					buf.WriteByte('}')
 				}
 			}
-			buf.WriteByte('}')
-			err = os.WriteFile(packageJsonPath, buf.Bytes(), 0644)
+			data, encodeErr := json.Marshal(packageData)
+			if encodeErr != nil {
+				return nil, encodeErr
+			}
+			err = os.WriteFile(packageJsonPath, data, 0644)
 			if err != nil {
 				return
 			}
@@ -504,7 +487,7 @@ func (npmrc *NpmRC) installDependenciesContext(ctx context.Context, wd string, p
 			if p.Name != "" {
 				pkg = p
 			}
-			if strings.HasSuffix(pkg.Name, "@types/") {
+			if strings.HasPrefix(pkg.Name, "@types/") {
 				// skip installing `@types/*` packages
 				return
 			}

--- a/server/npmrc_test.go
+++ b/server/npmrc_test.go
@@ -8,12 +8,15 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -49,6 +52,111 @@ func TestResolveSemverVersion(t *testing.T) {
 			got, err := resolveSemverVersion(metadata, test.version)
 			if got != test.want || (err != nil) != (test.want == "") {
 				t.Fatalf("resolveSemverVersion(%q) = %q, %v; want %q", test.version, got, err, test.want)
+			}
+		})
+	}
+}
+
+func TestResolveSemverOriginalVersion(t *testing.T) {
+	metadata := &npm.PackageMetadata{Versions: map[string]npm.PackageJSONRaw{
+		"v1.2.0": {Version: "v1.2.0"},
+	}}
+	got, err := resolveSemverVersion(metadata, "^1")
+	if err != nil || got != "v1.2.0" {
+		t.Fatalf("resolved version = %q, %v; want the original metadata key", got, err)
+	}
+}
+
+func BenchmarkResolveSemverVersion(b *testing.B) {
+	for _, count := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprint(count), func(b *testing.B) {
+			metadata := &npm.PackageMetadata{Versions: make(map[string]npm.PackageJSONRaw, count)}
+			for i := range count {
+				version := fmt.Sprintf("1.%d.0", i)
+				metadata.Versions[version] = npm.PackageJSONRaw{Version: version}
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if _, err := resolveSemverVersion(metadata, "^1"); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func TestInstallDependenciesSkipsTypes(t *testing.T) {
+	transport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = transport })
+	http.DefaultTransport = ghTestTransport(func(r *http.Request) (*http.Response, error) {
+		t.Errorf("unexpected request for a types-only dependency: %s", r.URL)
+		return &http.Response{StatusCode: http.StatusNotFound, Body: http.NoBody}, nil
+	})
+	npmrc := &NpmRC{globalRegistry: &NpmRegistry{NpmRegistryConfig: NpmRegistryConfig{Registry: npmRegistry}}}
+	err := npmrc.installDependencies(t.TempDir(), &npm.PackageJSON{
+		Name: "test", Version: "1.0.0",
+		Dependencies: map[string]string{"@types/test": "1.0.0", "types-alias": "npm:@types/test@1.0.0"},
+	}, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInstallGithubDenoConfig(t *testing.T) {
+	workDir, transport := config.WorkDir, http.DefaultTransport
+	config.WorkDir = t.TempDir()
+	t.Cleanup(func() { config.WorkDir, http.DefaultTransport = workDir, transport })
+	for _, test := range []struct {
+		name, filename, content string
+	}{
+		{"escaped strings", "deno.json", `{"imports":{"quote\"name":"./quote\"file.ts"},"exports":{".":"./a\\b.ts"}}`},
+		{"non-string entries", "deno.json", `{"imports":{"ignored":{"default":"./index.ts"}},"exports":{".":{"default":"./index.ts"}}}`},
+		{"comments", "deno.jsonc", "{\n// comment\n\"exports\":{\".\":\"./index.ts\"}}"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var archive bytes.Buffer
+			gz := gzip.NewWriter(&archive)
+			tw := tar.NewWriter(gz)
+			if err := tw.WriteHeader(&tar.Header{Name: "repo/" + test.filename, Mode: 0644, Size: int64(len(test.content))}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := io.WriteString(tw, test.content); err != nil {
+				t.Fatal(err)
+			}
+			if err := tw.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if err := gz.Close(); err != nil {
+				t.Fatal(err)
+			}
+			http.DefaultTransport = ghTestTransport(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(archive.Bytes()))}, nil
+			})
+			pkg := npm.Package{Github: true, Name: "owner/" + strings.ReplaceAll(test.name, " ", "-"), Version: "abcdef0"}
+			info, err := new(NpmRC).installPackage(pkg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.Name != pkg.Name || info.Version != pkg.Version {
+				t.Fatalf("incorrect generated package identity: %s@%s", info.Name, info.Version)
+			}
+			switch test.name {
+			case "escaped strings":
+				if got, _ := info.Imports.Get(`quote"name`); got != `./quote"file.ts` {
+					t.Fatalf("import = %q", got)
+				}
+				if got, _ := info.Exports.Get("."); got != `./a\b.ts` {
+					t.Fatalf("export = %q", got)
+				}
+			case "non-string entries":
+				if info.Imports.Len() != 0 || info.Exports.Len() != 0 {
+					t.Fatal("non-string entries should be omitted")
+				}
+			case "comments":
+				if got, _ := info.Exports.Get("."); got != "./index.ts" {
+					t.Fatalf("export = %q", got)
+				}
 			}
 		})
 	}

--- a/server/path.go
+++ b/server/path.go
@@ -256,34 +256,6 @@ func toPackageName(specifier string) string {
 	return name
 }
 
-// func normalizeSemver(version string) string {
-// 	buf := make([]byte, 3*len(version))
-// 	var i int
-// 	for _, char := range version {
-// 		switch char {
-// 		case ' ':
-// 			copy(buf[i:], "%20")
-// 			i += 3
-// 		case '^':
-// 			copy(buf[i:], "%5E")
-// 			i += 3
-// 		case '|':
-// 			copy(buf[i:], "%7C")
-// 			i += 3
-// 		case '<':
-// 			copy(buf[i:], "%3C")
-// 			i += 3
-// 		case '>':
-// 			copy(buf[i:], "%3E")
-// 			i += 3
-// 		default:
-// 			buf[i] = byte(char)
-// 			i++
-// 		}
-// 	}
-// 	return string(buf[:i])
-// }
-
 // isPackageInExternalNamespace checks if a package belongs to an external namespace
 // For example, if "@radix-ui" is in external, then "@radix-ui/react-dropdown" would match
 func isPackageInExternalNamespace(pkgName string, external set.ReadOnlySet[string]) bool {

--- a/server/utils.go
+++ b/server/utils.go
@@ -138,10 +138,7 @@ func findFiles(root string, dir string, filter func(filename string) bool) ([]st
 			if err != nil {
 				return nil, err
 			}
-			newFiles := make([]string, len(files)+len(subFiles))
-			copy(newFiles, files)
-			copy(newFiles[len(files):], subFiles)
-			files = newFiles
+			files = append(files, subFiles...)
 		} else {
 			if filter(filename) {
 				files = append(files, filename)

--- a/web/handler.go
+++ b/web/handler.go
@@ -3,6 +3,7 @@ package web
 import (
 	"bytes"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -209,25 +210,11 @@ func (s *Handler) ServeHtml(w http.ResponseWriter, r *http.Request, filename str
 	tokenizer := html.NewTokenizer(htmlFile)
 	hotLinks := []string{}
 	frameworkCSS := ""
-	overriding := ""
 
 	for {
 		tt := tokenizer.Next()
 		if tt == html.ErrorToken {
 			break
-		}
-		if overriding != "" {
-			if tt == html.TextToken {
-				continue
-			}
-			if tt == html.EndTagToken {
-				tagName, _ := tokenizer.TagName()
-				if string(tagName) == overriding {
-					overriding = ""
-					continue
-				}
-			}
-			overriding = ""
 		}
 		if tt == html.StartTagToken {
 			tagName, moreAttr := tokenizer.TagName()
@@ -547,9 +534,10 @@ func (s *Handler) ServeCSSModule(w http.ResponseWriter, r *http.Request, query u
 		header.Set("Cache-Control", "public, max-age=0, must-revalidate")
 		header.Set("Etag", etag)
 	}
-	w.Write([]byte("const css=\""))
-	w.Write(bytes.ReplaceAll(css, []byte{'"'}, []byte{'\\', '"'}))
-	w.Write([]byte("\";let style,"))
+	cssJSON, _ := json.Marshal(string(css))
+	w.Write([]byte("const css="))
+	w.Write(cssJSON)
+	w.Write([]byte(";let style,"))
 	w.Write([]byte(`applyCSS=css=>{(style??(style=document.head.appendChild(document.createElement("style")))).textContent=css};`))
 	if s.config.Dev {
 		w.Write([]byte(`import createHot from"/@hmr";`))
@@ -608,7 +596,7 @@ func (s *Handler) ServeFrameworkCSS(w http.ResponseWriter, r *http.Request, quer
 				} else if srcAttr == "" {
 					// inline script content
 					tokenizer.Next()
-					contents = append(contents, tokenizer.Text())
+					contents = append(contents, bytes.Clone(tokenizer.Text()))
 				} else {
 					if hrefAttr != "" && isHttpSepcifier(srcAttr) {
 						if !isHttpSepcifier(hrefAttr) && isModulePath(hrefAttr) {
@@ -621,7 +609,7 @@ func (s *Handler) ServeFrameworkCSS(w http.ResponseWriter, r *http.Request, quer
 			case "link", "meta", "title", "base", "head", "noscript":
 				// ignore
 			default:
-				contents = append(contents, tokenizer.Raw())
+				contents = append(contents, bytes.Clone(tokenizer.Raw()))
 			}
 		}
 	}
@@ -630,8 +618,9 @@ func (s *Handler) ServeFrameworkCSS(w http.ResponseWriter, r *http.Request, quer
 	if err != nil {
 		if os.IsNotExist(err) {
 			http.Error(w, "Not Found", 404)
+		} else {
+			http.Error(w, "Internal Server Error", 500)
 		}
-		http.Error(w, "Internal Server Error", 500)
 		return
 	}
 
@@ -643,7 +632,11 @@ func (s *Handler) ServeFrameworkCSS(w http.ResponseWriter, r *http.Request, quer
 		}
 	}
 	xx := xxhash.New()
-	xx.Write([]byte(configCSS))
+	xx.Write(configCSS)
+	for _, content := range contents {
+		xx.Write(content)
+		xx.Write([]byte{'\n'})
+	}
 	keys := make([]string, 0, len(tree))
 	for k := range tree {
 		keys = append(keys, k)
@@ -659,8 +652,8 @@ func (s *Handler) ServeFrameworkCSS(w http.ResponseWriter, r *http.Request, quer
 		w.WriteHeader(http.StatusNotModified)
 		return
 	}
-	cacheKey := framework
-	etagCacheKey := framework + ".etag"
+	cacheKey := framework + "-" + r.URL.Path
+	etagCacheKey := cacheKey + ".etag"
 	if css, ok := s.loaderCache.Load(cacheKey); ok {
 		if e, ok := s.loaderCache.Load(etagCacheKey); ok {
 			if e.(string) == etag {
@@ -820,6 +813,7 @@ func (s *Handler) getAppImportMap() (importMapRaw []byte, importMap *importmap.I
 
 func (s *Handler) analyzeDependencyTree(entry string, importMap *importmap.ImportMap) (tree map[string][]byte, err error) {
 	tree = make(map[string][]byte)
+	var treeLock sync.Mutex
 	ret := esbuild.Build(esbuild.BuildOptions{
 		EntryPoints:      []string{entry},
 		Target:           esbuild.ES2022,
@@ -856,7 +850,9 @@ func (s *Handler) analyzeDependencyTree(entry string, importMap *importmap.Impor
 						if err != nil {
 							return esbuild.OnLoadResult{}, err
 						}
+						treeLock.Lock()
 						tree[args.Path] = data
+						treeLock.Unlock()
 						contents := string(data)
 						loader := esbuild.LoaderJS
 						pathname := args.PluginData.(string)

--- a/web/handler_test.go
+++ b/web/handler_test.go
@@ -1,0 +1,99 @@
+package web
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestServeCSSModuleEscapesCSS(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "style.css"), []byte(`.icon:before{content:"\e001"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	handler := &Handler{config: &Config{AppDir: dir}}
+	r := httptest.NewRequest(http.MethodGet, "/style.css?module", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body.String())
+	}
+	literal, _, ok := strings.Cut(strings.TrimPrefix(w.Body.String(), "const css="), ";let style,")
+	var css string
+	if !ok || json.Unmarshal([]byte(literal), &css) != nil {
+		t.Fatalf("invalid CSS string literal: %s", literal)
+	}
+	if !strings.Contains(css, `\e001`) {
+		t.Fatalf("CSS escape lost: %s", css)
+	}
+}
+
+func TestFrameworkCSSUsesHTMLContent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "tailwind.css"), []byte(`@import "tailwindcss";`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	var input bytes.Buffer
+	handler := &Handler{
+		config: &Config{AppDir: dir},
+		loaderWorker: &JSWorker{
+			stdin:     &input,
+			outReader: bufio.NewReader(strings.NewReader(">>>css:\"first\"\n>>>css:\"second\"\n")),
+		},
+	}
+	var etag string
+	for i, class := range []string{"bg-red-500", "bg-blue-500"} {
+		source := "<html><body><div class=\"" + class + "\"></div>" + strings.Repeat("<p class=\"p-4\"></p>", 1000) + "</body></html>"
+		if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte(source), 0644); err != nil {
+			t.Fatal(err)
+		}
+		r := httptest.NewRequest(http.MethodGet, "/tailwind.css", nil)
+		r.Header.Set("If-None-Match", etag)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d: status %d, body %s", i, w.Code, w.Body.String())
+		}
+		etag = w.Header().Get("Etag")
+		var args []json.RawMessage
+		if err := json.Unmarshal(input.Bytes(), &args); err != nil {
+			t.Fatal(err)
+		}
+		var content string
+		if err := json.Unmarshal(args[2], &content); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(content, "<div class=\""+class+"\">") {
+			t.Fatalf("HTML content was overwritten: %.100s", content)
+		}
+		input.Reset()
+	}
+}
+
+func TestAnalyzeDependencyTreeConcurrentLoads(t *testing.T) {
+	dir := t.TempDir()
+	var entry strings.Builder
+	for i := range 64 {
+		name := fmt.Sprintf("module%d.js", i)
+		fmt.Fprintf(&entry, "import './%s';\n", name)
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("console.log(1)"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	filename := filepath.Join(dir, "main.js")
+	if err := os.WriteFile(filename, []byte(entry.String()), 0644); err != nil {
+		t.Fatal(err)
+	}
+	handler := &Handler{config: &Config{AppDir: dir}}
+	tree, err := handler.analyzeDependencyTree(filename, nil)
+	if err != nil || len(tree) != 65 {
+		t.Fatalf("tree contains %d files, error %v", len(tree), err)
+	}
+}

--- a/web/internal/loader.js
+++ b/web/internal/loader.js
@@ -155,7 +155,6 @@ async function tailwindCSS(_id, content, config) {
           }
           // todo: load and cache other css from npm
           throw new Error("could not find stylesheet id: " + id + ", sheetBase: " + sheetBase);
-          return null;
         },
       });
     })();
@@ -165,4 +164,3 @@ async function tailwindCSS(_id, content, config) {
   const { extract } = await once.oxide;
   return (await compiler).build(extract(content));
 }
-


### PR DESCRIPTION
Concurrent operations and failed I/O could corrupt cached files, lose import-map entries, or overwrite HTML after failed package resolution. This fixes those paths and several build, S3, and CLI errors found in the same review.

- Publish filesystem writes and lexer downloads only after successful completion; preserve existing files on failure and close S3 response bodies reliably.
- Follow S3 listing pagination, batch deletions with checksums, and surface per-object failures.
- Resolve the longest import-map prefix and synchronize dependency traversal, scope creation, CLI results, and web dependency loading.
- Preserve build arguments in declaration URLs and queue keys, reject corrupt splitting caches, and fix generated package metadata and CSS escaping.
- Repair npm bootstrap downloads, platform names, release tags, executable permissions, and exit status handling; preserve HTML and unmanaged imports during CLI updates.
- Remove dead code and unnecessary dependency traversal, replace version sorting with a linear scan, and avoid repeated directory-result copies.

Validation:

- `go test -race ./...`
- Staticcheck and `git diff --check`
- Debug lexer installation tests
- `bun test cli/npm/bootstrap.test.mjs` — 7 tests
- Deno transform, declaration, and raw-file suites — 6 tests against an isolated local server
- Version-resolution microbenchmark with 10,000 releases: median 3.44 ms → 2.50 ms across three runs on an Apple M4 Pro

S3 regressions use controlled HTTP responses; the credentialed live-S3 suite and full Deno suite are left to CI.
